### PR TITLE
Mongo resilient driver

### DIFF
--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriver.java
@@ -5,7 +5,10 @@ import io.vena.bosk.Bosk;
 import io.vena.bosk.BoskDriver;
 import io.vena.bosk.DriverFactory;
 import io.vena.bosk.Entity;
+import io.vena.bosk.drivers.mongo.v2.MainDriver;
 import java.io.IOException;
+
+import static io.vena.bosk.drivers.mongo.MongoDriverSettings.ImplementationKind.RESILIENT;
 
 public interface MongoDriver<R extends Entity> extends BoskDriver<R> {
 	/**
@@ -40,7 +43,11 @@ public interface MongoDriver<R extends Entity> extends BoskDriver<R> {
 		MongoDriverSettings driverSettings,
 		BsonPlugin bsonPlugin
 	) {
-		return (b, d) -> new SingleDocumentMongoDriver<>(b, clientSettings, driverSettings, bsonPlugin, d);
+		if (driverSettings.implementationKind() == RESILIENT) {
+			return (b, d) -> new MainDriver<>(b, clientSettings, driverSettings, bsonPlugin, d);
+		} else {
+			return (b, d) -> new SingleDocumentMongoDriver<>(b, clientSettings, driverSettings, bsonPlugin, d);
+		}
 	}
 
 	interface MongoDriverFactory<RR extends Entity> extends DriverFactory<RR> {

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
@@ -13,6 +13,7 @@ public class MongoDriverSettings {
 
 	@Default long flushTimeoutMS = 30_000;
 	@Default FlushMode flushMode = FlushMode.ECHO;
+	@Default ImplementationKind implementationKind = ImplementationKind.STABLE;
 	@Default Testing testing = Testing.builder().build();
 
 	@Value
@@ -52,5 +53,21 @@ public class MongoDriverSettings {
 		 * and runs as quickly as a single database read.
 		 */
 		REVISION_FIELD_ONLY,
+	}
+
+	public enum ImplementationKind {
+		/**
+		 * The more mature, well-tested implementation.
+		 */
+		STABLE,
+
+		/**
+		 * <strong>Experimental</strong>
+		 *
+		 * <p>
+		 * A newer implementation with better resiliency features.
+		 * Ignores {@link FlushMode FlushMode}; only supports the equivalent of {@link FlushMode#REVISION_FIELD_ONLY REVISION_FIELD_ONLY}.
+		 */
+		RESILIENT,
 	}
 }

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ChangeEventListener.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ChangeEventListener.java
@@ -1,0 +1,9 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import org.bson.Document;
+
+interface ChangeEventListener {
+	void onEvent(ChangeStreamDocument<Document> event);
+	void onException(Exception e);
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ChangeEventReceiver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ChangeEventReceiver.java
@@ -1,0 +1,221 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoInterruptedException;
+import com.mongodb.client.MongoChangeStreamCursor;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import io.vena.bosk.exceptions.NotYetImplementedException;
+import java.io.Closeable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.var;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Has three jobs:
+ *
+ * <ol><li>
+ *     does inversion of control on the change stream cursor,
+ *     calling {@link ChangeEventListener} callback methods on a background thread,
+ * </li><li>
+ *     catches event-processing exceptions and reports them to {@link ChangeEventListener#onException}
+ *     so the listener can initiate a clean reinitialization and recovery sequence, and
+ * </li><li>
+ *     acts as a long-lived container for the various transient objects ({@link MongoChangeStreamCursor},
+ *     {@link ChangeEventListener}) that get replaced during reinitialization.
+ * </li></ol>
+ *
+ */
+@RequiredArgsConstructor
+class ChangeEventReceiver implements Closeable {
+	private final String boskName;
+	private final MongoCollection<Document> collection;
+	private final ExecutorService ex = Executors.newFixedThreadPool(1);
+
+	private final Lock lock = new ReentrantLock();
+	private volatile Session currentSession;
+	private volatile BsonDocument lastProcessedResumeToken;
+	private volatile Future<?> eventProcessingTask;
+
+	@AllArgsConstructor
+	private static final class Session {
+		final MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor;
+		final ChangeEventListener listener;
+		ChangeStreamDocument<Document> initialEvent;
+	}
+
+	/**
+	 * Sets up an event processing loop so that it will start feeding events to
+	 * <code>listener</code> when {@link #start()} is called.
+	 * No events will be sent to <code>listener</code> before {@link #start()} has been called.
+	 *
+	 * <p>
+	 * Shuts down the existing event processing loop, if any:
+	 * this method has been specifically designed to be called more than once,
+	 * in case you're wondering why we wouldn't just do this in the constructor.
+	 * This method is also designed to support being called on the event-processing
+	 * thread itself, since a re-initialization could be triggered by an event or exception.
+	 * For example, a {@link ChangeEventListener#onException} implementation can call this.
+	 *
+	 * @return true if we obtained a resume token.
+	 * @see #start()
+	 */
+	public boolean initialize(ChangeEventListener listener) throws ReceiverInitializationException {
+		LOGGER.debug("Initializing receiver");
+		try {
+			lock.lock();
+			stop();
+			setupNewSession(listener);
+			return lastProcessedResumeToken != null;
+		} catch (RuntimeException | InterruptedException | TimeoutException e) {
+			throw new ReceiverInitializationException(e);
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	public boolean isReady() {
+		return currentSession != null;
+	}
+
+	public void start() {
+		try {
+			lock.lock();
+			if (currentSession == null) {
+				throw new IllegalStateException("Receiver is not initialized");
+			}
+			if (eventProcessingTask == null) {
+				eventProcessingTask = ex.submit(() -> eventProcessingLoop(currentSession));
+			} else {
+				LOGGER.debug("Already running");
+			}
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	public void stop() throws InterruptedException, TimeoutException {
+		try {
+			lock.lock();
+			Future<?> task = this.eventProcessingTask;
+			if (task != null) {
+				LOGGER.debug("Canceling event processing task");
+				task.cancel(true);
+				try {
+					task.get(10, SECONDS); // TODO: Config
+					LOGGER.warn("Normal completion of event processing task was not expected");
+				} catch (CancellationException e) {
+					LOGGER.debug("Cancellation succeeded; event loop interrupted");
+					this.eventProcessingTask = null;
+				}
+			}
+		} catch (ExecutionException e) {
+			throw new NotYetImplementedException("Event processing loop isn't supposed to throw!", e);
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public void close() {
+		try {
+			stop();
+		} catch (TimeoutException | InterruptedException e) {
+			LOGGER.info("Ignoring exception while closing ChangeEventReceiver", e);
+		}
+		ex.shutdown();
+	}
+
+	private void setupNewSession(ChangeEventListener newListener) {
+		assert this.eventProcessingTask == null;
+		LOGGER.debug("Setup new session");
+		this.currentSession = null; // In case any exceptions happen during this method
+
+		for (int attempt = 1; attempt <= 2; attempt++) {
+			LOGGER.debug("Attempt #{}", attempt);
+			ChangeStreamDocument<Document> initialEvent;
+			BsonDocument resumePoint = lastProcessedResumeToken;
+			if (resumePoint == null) {
+				LOGGER.debug("Acquire initial resume token");
+				// TODO: Config
+				// Note: on a quiescent collection, tryNext() will wait for the Await Time to elapse, so keep it short
+				try (var initialCursor = collection.watch().maxAwaitTime(20, MILLISECONDS).cursor()) {
+					initialEvent = initialCursor.tryNext();
+					if (initialEvent == null) {
+						// In this case, tryNext() has caused the cursor to point to
+						// a token in the past, so we can reliably use that.
+						resumePoint = requireNonNull(initialCursor.getResumeToken(),
+							"Cannot proceed without an initial resume token");
+						lastProcessedResumeToken = resumePoint;
+					} else {
+						LOGGER.debug("Received event while acquiring initial resume token; storing it for processing in event loop");
+						resumePoint = initialEvent.getResumeToken();
+					}
+				}
+			} else {
+				LOGGER.debug("Use existing resume token");
+				initialEvent = null;
+			}
+			try {
+				MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor
+					= collection.watch().resumeAfter(resumePoint).cursor();
+				currentSession = new Session(cursor, newListener, initialEvent);
+				return;
+			} catch (MongoCommandException e) {
+				LOGGER.error("Change stream cursor command failed; discarding resume token", e);
+				lastProcessedResumeToken = null;
+				// If we haven't already retried, we'll continue around the loop
+			}
+		}
+	}
+
+	/**
+	 * This method has no uncaught exceptions. They're all reported to {@link ChangeEventListener#onException}.
+	 */
+	private void eventProcessingLoop(Session session) {
+		String oldThreadName = currentThread().getName();
+		currentThread().setName(getClass().getSimpleName() + " [" + boskName + "]");
+		try {
+			if (session.initialEvent != null) {
+				processEvent(session, session.initialEvent);
+				session.initialEvent = null; // Allow GC
+			}
+			while (true) {
+				processEvent(session, session.cursor.next());
+			}
+		} catch (MongoInterruptedException e) {
+			// This happens when stop() cancels the task; this is part of normal operation
+			LOGGER.debug("Event loop interrupted", e);
+			session.listener.onException(e);
+		} catch (RuntimeException e) {
+			LOGGER.warn("Unexpected exception while processing events; event loop aborted", e);
+			session.listener.onException(e);
+		} finally {
+			currentThread().setName(oldThreadName);
+		}
+	}
+
+	private void processEvent(Session session, ChangeStreamDocument<Document> event) {
+		session.listener.onEvent(event);
+		lastProcessedResumeToken = event.getResumeToken();
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ChangeEventReceiver.class);
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/DisconnectedDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/DisconnectedDriver.java
@@ -1,0 +1,77 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import io.vena.bosk.Entity;
+import io.vena.bosk.Identifier;
+import io.vena.bosk.Reference;
+import java.io.IOException;
+import org.bson.BsonInt64;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class DisconnectedDriver<R extends Entity> implements FormatDriver<R> {
+	@Override
+	public boolean isDisconnected() {
+		return true;
+	}
+
+	@Override
+	public <T> void submitReplacement(Reference<T> target, T newValue) {
+		throw disconnected("submitReplacement");
+	}
+
+	@Override
+	public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
+		throw disconnected("submitConditionalReplacement");
+	}
+
+	@Override
+	public <T> void submitInitialization(Reference<T> target, T newValue) {
+		throw disconnected("submitInitialization");
+	}
+
+	@Override
+	public <T> void submitDeletion(Reference<T> target) {
+		throw disconnected("submitDeletion");
+	}
+
+	@Override
+	public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
+		throw disconnected("submitConditionalDeletion");
+	}
+
+	@Override
+	public void flush() throws IOException, InterruptedException {
+		throw disconnected("flush");
+	}
+
+	@Override
+	public void close() { }
+
+	@Override
+	public StateAndMetadata<R> loadAllState() {
+		throw disconnected("loadAllState");
+	}
+
+	@Override
+	public void initializeCollection(StateAndMetadata<R> contents) {
+
+	}
+
+	@Override
+	public void onRevisionToSkip(BsonInt64 revision) {
+		throw new AssertionError("Resynchronization should not tell DisconnectedDriver to skip a revision");
+	}
+
+	private DisconnectedException disconnected(String name) {
+		return new DisconnectedException("Disconnected driver cannot execute " + name);
+	}
+
+	@Override
+	public void onEvent(ChangeStreamDocument<Document> event) {
+		LOGGER.info("Event received in disconnected mode: {} {}", event.getOperationType(), event.getResumeToken());
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DisconnectedDriver.class);
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/DisconnectedException.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/DisconnectedException.java
@@ -1,0 +1,18 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+public class DisconnectedException extends RuntimeException {
+	public DisconnectedException() {
+	}
+
+	public DisconnectedException(String message) {
+		super(message);
+	}
+
+	public DisconnectedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public DisconnectedException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FlushLock.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FlushLock.java
@@ -1,0 +1,99 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+import io.vena.bosk.drivers.mongo.MongoDriverSettings;
+import io.vena.bosk.exceptions.FlushFailureException;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.Semaphore;
+import lombok.Value;
+import org.bson.BsonInt64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Implements waiting mechanism for revision numbers
+ */
+class FlushLock {
+	private final MongoDriverSettings settings;
+	private final PriorityBlockingQueue<Waiter> queue = new PriorityBlockingQueue<>();
+	private volatile long alreadySeen;
+
+	/**
+	 * @param revisionAlreadySeen needs to be the exact revision from the database:
+	 * too old, and we'll wait forever for intervening revisions that have already happened;
+	 * too new, and we'll proceed immediately without waiting for revisions that haven't happened yet.
+	 */
+	public FlushLock(MongoDriverSettings settings, long revisionAlreadySeen) {
+		this.settings = settings;
+		this.alreadySeen = revisionAlreadySeen;
+	}
+
+	@Value
+	private static class Waiter implements Comparable<Waiter> {
+		long revision;
+		Semaphore semaphore;
+
+		@Override
+		public int compareTo(Waiter other) {
+			return Long.compare(revision, other.revision);
+		}
+	}
+
+	void awaitRevision(BsonInt64 revision) throws InterruptedException, FlushFailureException {
+		long revisionValue = revision.longValue();
+		Semaphore semaphore = new Semaphore(0);
+		queue.add(new Waiter(revisionValue, semaphore));
+		long past = alreadySeen;
+		if (revisionValue > past) {
+			LOGGER.debug("Awaiting revision {} > {}", revisionValue, past);
+			if (!semaphore.tryAcquire(settings.flushTimeoutMS(), MILLISECONDS)) {
+				throw new FlushFailureException("Timed out waiting for revision " + revisionValue);
+			}
+		} else {
+			LOGGER.debug("Revision {} is in the past; don't wait", revisionValue);
+			return;
+		}
+		LOGGER.trace("Done awaiting revision {}", revisionValue);
+	}
+
+	/**
+	 * @param revision can be null
+	 */
+	public void startedRevision(BsonInt64 revision) {
+		if (revision == null) {
+			return;
+		}
+		long revisionValue = revision.longValue();
+		assert alreadySeen <= revisionValue;
+		alreadySeen = revisionValue;
+		LOGGER.debug("Seen {}", revisionValue);
+	}
+
+	/**
+	 * @param revision can be null
+	 */
+	void finishedRevision(BsonInt64 revision) {
+		if (revision == null) {
+			return;
+		}
+		long revisionValue = revision.longValue();
+		boolean foundWaiter = false;
+		do {
+			Waiter w = queue.peek();
+			if (w == null || w.revision > revisionValue) {
+				return;
+			} else {
+				Waiter removed = queue.remove();
+				assert w == removed;
+				if (!foundWaiter) {
+					foundWaiter = true;
+					LOGGER.debug("Notified thread waiting for {}", revisionValue);
+				}
+				w.semaphore.release();
+			}
+		} while (true);
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(FlushLock.class);
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FormatDriver.java
@@ -1,0 +1,68 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+import com.mongodb.client.MongoChangeStreamCursor;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import io.vena.bosk.Entity;
+import io.vena.bosk.drivers.mongo.MongoDriver;
+import io.vena.bosk.exceptions.InitializationFailureException;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import org.bson.BsonInt64;
+import org.bson.Document;
+
+/**
+ * Additional {@link MongoDriver} functionality that the format-specific drivers must implement.
+ * <p>
+ * Implementations of this are responsible for the following:
+ * <ol><li>
+ *     Serializing and deserializing the database contents
+ * </li><li>
+ *     Processing change stream events via {@link #onEvent}
+ * </li><li>
+ *     Managing revision numbers (eg. {@link #onRevisionToSkip}
+ * </li><li>
+ *     Implementing {@link #flush()} (consider using {@link FlushLock})
+ * </li></ol>
+ *
+ * Implementations are not responsible for:
+ * <ol><li>
+ *     Handling exceptions from {@link MongoClient} or {@link MongoChangeStreamCursor}
+ * </li><li>
+ *     Determining the database format
+ * </li><li>
+ *     Implementing {@link #initialRoot} or {@link #refurbish()}
+ * </li></ol>
+ */
+interface FormatDriver<R extends Entity> extends MongoDriver<R> {
+	void onEvent(ChangeStreamDocument<Document> event);
+
+	/**
+	 * Implementations should ignore subsequent calls to {@link #onEvent}
+	 * associated with revisions less than or equal to <code>revision</code>.
+	 * @param revision the last revision to skip
+	 */
+	void onRevisionToSkip(BsonInt64 revision);
+
+	StateAndMetadata<R> loadAllState() throws IOException, UninitializedCollectionException;
+
+	/**
+	 * Can assume that the collection is empty or nonexistent.
+	 * Can assume it's called in a transaction.
+	 */
+	void initializeCollection(StateAndMetadata<R> contents) throws InitializationFailureException;
+
+	default boolean isDisconnected() { return false; }
+
+	@Override
+	default R initialRoot(Type rootType) {
+		throw new UnsupportedOperationException(
+			"FormatDriver doesn't need to implement initialRoot: MainDriver derives it from loadAllState");
+	}
+
+	@Override
+	default void refurbish() {
+		throw new UnsupportedOperationException(
+			"FormatDriver doesn't need to implement refurbish: MainDriver derives it from loadAllState and initializeCollection");
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/Formatter.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/Formatter.java
@@ -1,0 +1,302 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+import io.vena.bosk.Bosk;
+import io.vena.bosk.Listing;
+import io.vena.bosk.Reference;
+import io.vena.bosk.SerializationPlugin;
+import io.vena.bosk.SideTable;
+import io.vena.bosk.drivers.mongo.BsonPlugin;
+import io.vena.bosk.exceptions.InvalidTypeException;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Type;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWriter;
+import org.bson.BsonInt64;
+import org.bson.BsonReader;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.DocumentCodecProvider;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.ValueCodecProvider;
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import static io.vena.bosk.ReferenceUtils.rawClass;
+import static java.lang.String.format;
+
+/**
+ * Facilities to translate between in-DB and in-memory representations.
+ *
+ * @author pdoyle
+ */
+final class Formatter {
+	private final CodecRegistry simpleCodecs;
+	private final Function<Type, Codec<?>> preferredBoskCodecs;
+	private final Function<Reference<?>, SerializationPlugin.DeserializationScope> deserializationScopeFunction;
+
+	Formatter(Bosk<?> bosk, BsonPlugin bsonPlugin) {
+		this.simpleCodecs = CodecRegistries.fromProviders(bsonPlugin.codecProviderFor(bosk), new ValueCodecProvider(), new DocumentCodecProvider());
+		this.preferredBoskCodecs = type -> bsonPlugin.getCodec(type, rawClass(type), simpleCodecs, bosk);
+		this.deserializationScopeFunction = bsonPlugin::newDeserializationScope;
+	}
+
+	/**
+	 * Revision number zero represents a nonexistent version number,
+	 * consistent with the behaviour of the MongoDB <code>$inc</code> operator,
+	 * which treats a nonexistent field as a zero.
+	 * For us, this occurs in two situations:
+	 *
+	 * <ol><li>
+	 *     Initialization: There is no state information yet because the document doesn't exist
+	 * </li><li>
+	 *     Legacy: The database collection pre-dates revision numbers and doesn't have one
+	 * </li></ol>
+	 *
+	 * The revision field in the database is never less than this value: it is initialized to
+	 * {@link #REVISION_ONE} and incremented thereafter. Therefore, waiting for a revision
+	 * greater than or equal to this is equivalent to waiting for any update at all.
+	 */
+	static final BsonInt64 REVISION_ZERO = new BsonInt64(0);
+
+	/**
+	 * The revision number used when the bosk document is first created.
+	 */
+	static final BsonInt64 REVISION_ONE = new BsonInt64(1);
+
+	/**
+	 * The fields of the main MongoDB document.  Case-sensitive.
+	 *
+	 * <p>
+	 * No field name should be a prefix of any other.
+	 */
+	enum DocumentFields {
+		path,
+		state,
+		echo,
+		revision,
+	}
+
+	//
+	// Helpers to translate Bosk <-> MongoDB
+	//
+
+	Codec<?> codecFor(Type type) {
+		// BsonPlugin gives better codecs than CodecRegistry, because BsonPlugin is aware of generics,
+		// so we always try that first. The CodecSupplier protocol uses "null" to indicate that another
+		// CodecSupplier should be used, so we follow that protocol and fall back on the CodecRegistry.
+		// TODO: Should this logic be in BsonPlugin? It has nothing to do with MongoDriver really.
+		Codec<?> result = preferredBoskCodecs.apply(type);
+		if (result == null) {
+			return simpleCodecs.get(rawClass(type));
+		} else {
+			return result;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	<T> T document2object(Document document, Reference<T> target) {
+		BsonDocument doc = document.toBsonDocument(BsonDocument.class, simpleCodecs);
+		Type type = target.targetType();
+		Class<T> objectClass = (Class<T>) rawClass(type);
+		Codec<T> objectCodec = (Codec<T>) codecFor(type);
+		try (@SuppressWarnings("unused") BsonPlugin.DeserializationScope scope = deserializationScopeFunction.apply(target)) {
+			return objectClass.cast(objectCodec.decode(doc.asBsonReader(), DecoderContext.builder().build()));
+		}
+	}
+
+	/**
+	 * @see #bsonValue2object(BsonValue, Reference)
+	 */
+	@SuppressWarnings("unchecked")
+	<T> BsonValue object2bsonValue(T object, Type type) {
+		rawClass(type).cast(object);
+		Codec<T> objectCodec = (Codec<T>) codecFor(type);
+		BsonDocument document = new BsonDocument();
+		try (BsonDocumentWriter writer = new BsonDocumentWriter(document)) {
+			// To support arbitrary values, not just whole documents, we put the result INSIDE a document.
+			writer.writeStartDocument();
+			writer.writeName("value");
+			objectCodec.encode(writer, object, EncoderContext.builder().build());
+			writer.writeEndDocument();
+		}
+		return document.get("value");
+	}
+
+	/**
+	 * @see #object2bsonValue(Object, Type)
+	 */
+	@SuppressWarnings("unchecked")
+	<T> T bsonValue2object(BsonValue bson, Reference<T> target) {
+		Codec<T> objectCodec = (Codec<T>) codecFor(target.targetType());
+		BsonDocument document = new BsonDocument();
+		document.append("value", bson);
+		try (
+			@SuppressWarnings("unused") BsonPlugin.DeserializationScope scope = deserializationScopeFunction.apply(target);
+			BsonReader reader = document.asBsonReader()
+		) {
+			reader.readStartDocument();
+			reader.readName("value");
+			return objectCodec.decode(reader, DecoderContext.builder().build());
+		}
+	}
+
+	/**
+	 * @return MongoDB field name corresponding to the given Reference
+	 * @see #referenceTo(String, Reference)
+	 */
+	static <T> String dottedFieldNameOf(Reference<T> ref, Reference<?> startingRef) {
+		ArrayList<String> segments = dottedFieldNameSegments(ref, startingRef);
+		return String.join(".", segments.toArray(new String[0]));
+	}
+
+	static <T> ArrayList<String> dottedFieldNameSegments(Reference<T> ref, Reference<?> startingRef) {
+		assert startingRef.path().isPrefixOf(ref.path()): "'" + ref + "' must be under '" + startingRef + "'";
+		ArrayList<String> segments = new ArrayList<>();
+		segments.add(DocumentFields.state.name());
+		buildDottedFieldNameOf(ref, startingRef.path().length(), segments);
+		return segments;
+	}
+
+	private static <T> void buildDottedFieldNameOf(Reference<T> ref, int startingRefLength, ArrayList<String> segments) {
+		if (ref.path().length() > startingRefLength) {
+			Reference<?> enclosingReference = enclosingReference(ref);
+			buildDottedFieldNameOf(enclosingReference, startingRefLength, segments);
+			if (Listing.class.isAssignableFrom(enclosingReference.targetClass())) {
+				segments.add("ids");
+			} else if (SideTable.class.isAssignableFrom(enclosingReference.targetClass())) {
+				segments.add("valuesById");
+			}
+			segments.add(dottedFieldNameSegment(ref.path().lastSegment()));
+		}
+	}
+
+	static String dottedFieldNameSegment(String segment) {
+		return ENCODER.apply(segment);
+	}
+
+	static String undottedFieldNameSegment(String dottedSegment) {
+		return DECODER.apply(dottedSegment);
+	}
+
+	/**
+	 * @return Reference corresponding to the given field name
+	 * @see #dottedFieldNameOf(Reference, Reference)
+	 */
+	@SuppressWarnings("unchecked")
+	static <T> Reference<T> referenceTo(String dottedName, Reference<?> startingReference) throws InvalidTypeException {
+		Reference<?> ref = startingReference;
+		Iterator<String> iter = Arrays.asList(dottedName.split(Pattern.quote("."))).iterator();
+		skipField(ref, iter, DocumentFields.state.name()); // The entire Bosk state is in this field
+		while (iter.hasNext()) {
+			if (Listing.class.isAssignableFrom(ref.targetClass())) {
+				skipField(ref, iter, "ids");
+			} else if (SideTable.class.isAssignableFrom(ref.targetClass())) {
+				skipField(ref, iter, "valuesById");
+			}
+			if (iter.hasNext()) {
+				String segment = undottedFieldNameSegment(iter.next());
+				ref = ref.then(Object.class, segment);
+			}
+		}
+		return (Reference<T>) ref;
+	}
+
+	private static void skipField(Reference<?> ref, Iterator<String> iter, String expectedName) {
+		String actualName;
+		try {
+			actualName = iter.next();
+		} catch (NoSuchElementException e) {
+			throw new IllegalStateException("Expected '" + expectedName + "' for " + ref.targetClass().getSimpleName() + "; encountered end of dotted field name");
+		}
+		if (!expectedName.equals(actualName)) {
+			throw new IllegalStateException("Expected '" + expectedName + "' for " + ref.targetClass().getSimpleName() + "; was: " + actualName);
+		}
+	}
+
+	/**
+	 * If the reference is not a root reference, it always has an enclosing reference
+	 * conforming to Object, so this can't throw. Eat the InvalidTypeException.
+	 */
+	static <T> Reference<?> enclosingReference(Reference<T> ref) {
+		assert !ref.path().isEmpty();
+		try {
+			return ref.enclosingReference(Object.class);
+		} catch (InvalidTypeException e) {
+			throw new AssertionError(format("Reference must have an enclosing Object: '%s'", ref), e);
+		}
+	}
+
+	private static final UnaryOperator<String> DECODER;
+	private static final UnaryOperator<String> ENCODER;
+
+	static {
+		DECODER = s->{
+			try {
+				return URLDecoder.decode(s, StandardCharsets.UTF_8.name());
+			} catch (UnsupportedEncodingException e) {
+				throw new AssertionError(e);
+			}
+		};
+
+		ENCODER = s->{
+			// Selective percent-encoding of characters MongoDB doesn't like.
+			// Standard percent-encoding doesn't handle the period character, which
+			// we want, so if we're already diverging from the standard, we might
+			// as well do something that suits our needs.
+			// Good to stay compatible with standard percent-DEcoding, though.
+			StringBuilder sb = new StringBuilder();
+			for (int i = 0; i < s.length(); ) {
+				int cp = s.codePointAt(i);
+				switch (cp) {
+					case '%': // For percent-encoding
+					case '+': case ' ': // These two are affected by URLDecoder
+					case '$': // MongoDB treats these specially
+					case '.': // MongoDB separator for dotted field names
+					case 0:   // Can MongoDB handle nulls? Probably. Do we want to find out? Not really.
+					case '|': // (These are reserved for internal use)
+					case '!':
+					case '~':
+					case '[':
+					case ']':
+						appendPercentEncoded(sb, cp);
+						break;
+					default:
+						sb.appendCodePoint(cp);
+						break;
+				}
+				i += Character.charCount(cp);
+			}
+			return sb.toString();
+		};
+	}
+
+	private static void appendPercentEncoded(StringBuilder sb, int cp) {
+		assert 0 <= cp && cp <= 255;
+		sb
+			.append('%')
+			.append(hexCharForDigit(cp / 16))
+			.append(hexCharForDigit(cp % 16));
+	}
+
+	/**
+	 * An uppercase version of {@link Character#forDigit} with a radix of 16.
+	 */
+	private static char hexCharForDigit(int value) {
+		if (value < 10) {
+			return (char)('0' + value);
+		} else {
+			return (char)('A' + value - 10);
+		}
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
@@ -1,0 +1,393 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+import com.mongodb.ClientSessionOptions;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.ReadConcern;
+import com.mongodb.TransactionOptions;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import io.vena.bosk.Bosk;
+import io.vena.bosk.BoskDriver;
+import io.vena.bosk.Entity;
+import io.vena.bosk.Identifier;
+import io.vena.bosk.Reference;
+import io.vena.bosk.drivers.mongo.BsonPlugin;
+import io.vena.bosk.drivers.mongo.MongoDriver;
+import io.vena.bosk.drivers.mongo.MongoDriverSettings;
+import io.vena.bosk.drivers.mongo.v2.Formatter.DocumentFields;
+import io.vena.bosk.exceptions.FlushFailureException;
+import io.vena.bosk.exceptions.InvalidTypeException;
+import io.vena.bosk.exceptions.NotYetImplementedException;
+import io.vena.bosk.exceptions.TunneledCheckedException;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicReference;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.vena.bosk.drivers.mongo.v2.Formatter.REVISION_ONE;
+
+public class MainDriver<R extends Entity> implements MongoDriver<R> {
+	private final Bosk<R> bosk;
+	private final MongoDriverSettings driverSettings;
+	private final BsonPlugin bsonPlugin;
+	private final BoskDriver<R> downstream;
+
+	private final Reference<R> rootRef;
+	private final MongoClient mongoClient;
+	private final MongoDatabase database;
+	private final MongoCollection<Document> collection;
+	private final ChangeEventReceiver receiver;
+
+	private final AtomicReference<FutureTask<R>> initializationInProgress = new AtomicReference<>();
+	private volatile FormatDriver<R> formatDriver = new DisconnectedDriver<>();
+	private volatile boolean isClosed = false;
+
+	public MainDriver(
+		Bosk<R> bosk,
+		MongoClientSettings clientSettings,
+		MongoDriverSettings driverSettings,
+		BsonPlugin bsonPlugin,
+		BoskDriver<R> downstream
+		) {
+		validateMongoClientSettings(clientSettings);
+
+		this.bosk = bosk;
+		this.driverSettings = driverSettings;
+		this.bsonPlugin = bsonPlugin;
+		this.downstream = downstream;
+
+		this.rootRef = bosk.rootReference();
+		this.mongoClient = MongoClients.create(clientSettings);
+		this.database = mongoClient
+			.getDatabase(driverSettings.database());
+		this.collection = database
+			.getCollection(COLLECTION_NAME);
+		this.receiver = new ChangeEventReceiver(bosk.name(), collection);
+	}
+
+	private void validateMongoClientSettings(MongoClientSettings clientSettings) {
+		// We require ReadConcern and WriteConcern to be MAJORITY to ensure the Causal Consistency
+		// guarantees needed to meet the requirements of the BoskDriver interface.
+		// https://www.mongodb.com/docs/manual/core/causal-consistency-read-write-concerns/
+
+		if (clientSettings.getReadConcern() != ReadConcern.MAJORITY) {
+			throw new IllegalArgumentException("MongoDriver requires MongoClientSettings to specify ReadConcern.MAJORITY");
+		}
+		if (clientSettings.getWriteConcern() != WriteConcern.MAJORITY) {
+			throw new IllegalArgumentException("MongoDriver requires MongoClientSettings to specify WriteConcern.MAJORITY");
+		}
+	}
+
+	@Override
+	public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+		beginDriverOperation("initialRoot");
+		R result;
+		try {
+			result = initializeReplication();
+		} catch (UninitializedCollectionException e) {
+			if (LOGGER.isTraceEnabled()) {
+				LOGGER.trace("Creating collection", e);
+			} else {
+				LOGGER.info("Creating collection");
+			}
+			FormatDriver<R> newDriver = newSingleDocFormatDriver(REVISION_ONE.longValue()); // TODO: Pick based on config?
+			result = downstream.initialRoot(rootType);
+			newDriver.initializeCollection(new StateAndMetadata<>(result, REVISION_ONE));
+			formatDriver = newDriver;
+		} catch (ReceiverInitializationException e) {
+			LOGGER.debug("Unable to initialize replication", e);
+			result = null;
+		}
+		if (receiver.isReady()) {
+			receiver.start();
+		} else {
+			LOGGER.debug("Receiver not started");
+		}
+		if (result == null) {
+			return downstream.initialRoot(rootType);
+		} else {
+			return result;
+		}
+	}
+
+	private void recoverFrom(Exception exception) {
+		if (isClosed) {
+			LOGGER.debug("Closed driver ignoring exception", exception);
+			return;
+		}
+		LOGGER.error("Recovering from unexpected exception; reinitializing", exception);
+		R result;
+		try {
+			result = initializeReplication();
+		} catch (UninitializedCollectionException e) {
+			LOGGER.warn("Collection is uninitialized; driver is disconnected", e);
+			return;
+		} catch (ReceiverInitializationException e) {
+			LOGGER.warn("Unable to initialize receiver", e);
+			return;
+		}
+		if (result != null) {
+			// Because we haven't called receiver.start() yet, this won't race with other events
+			downstream.submitReplacement(rootRef, result);
+		}
+		if (!isClosed) {
+			receiver.start();
+		}
+	}
+
+	@Override
+	public <T> void submitReplacement(Reference<T> target, T newValue) {
+		beginDriverOperation("submitReplacement({})", target);
+		retryIfDisconnected(() ->
+			formatDriver.submitReplacement(target, newValue));
+	}
+
+	@Override
+	public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
+		beginDriverOperation("submitConditionalReplacement({}, {} = {})", target, precondition, requiredValue);
+		retryIfDisconnected(() ->
+			formatDriver.submitConditionalReplacement(target, newValue, precondition, requiredValue));
+	}
+
+	@Override
+	public <T> void submitInitialization(Reference<T> target, T newValue) {
+		beginDriverOperation("submitInitialization({})", target);
+		retryIfDisconnected(() ->
+			formatDriver.submitInitialization(target, newValue));
+	}
+
+	@Override
+	public <T> void submitDeletion(Reference<T> target) {
+		beginDriverOperation("submitDeletion({}, {})", target);
+		retryIfDisconnected(() ->
+			formatDriver.submitDeletion(target));
+	}
+
+	@Override
+	public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
+		beginDriverOperation("submitConditionalDeletion({}, {} = {})", target, precondition, requiredValue);
+		retryIfDisconnected(() ->
+			formatDriver.submitConditionalDeletion(target, precondition, requiredValue));
+	}
+
+	@Override
+	public void flush() throws IOException, InterruptedException {
+		beginDriverOperation("flush");
+		try {
+			this.<IOException, InterruptedException>retryIfDisconnected(() ->
+				formatDriver.flush());
+		} catch (DisconnectedException e) {
+			throw new FlushFailureException("Unable to connect to database", e);
+		}
+	}
+
+	@Override
+	public void refurbish() throws IOException {
+		beginDriverOperation("refurbish");
+		retryIfDisconnected(this::doRefurbish);
+	}
+
+	private void doRefurbish() throws IOException {
+		ClientSessionOptions sessionOptions = ClientSessionOptions.builder()
+			.causallyConsistent(true)
+			.defaultTransactionOptions(TransactionOptions.builder()
+				.writeConcern(WriteConcern.MAJORITY)
+				.readConcern(ReadConcern.MAJORITY)
+				.build())
+			.build();
+		try (ClientSession session = mongoClient.startSession(sessionOptions)) {
+			try {
+				// Design note: this operation shouldn't do any special coordination with
+				// the receiver/listener system, because other replicas won't.
+				// That system needs to cope with a refurbish operations without any help.
+				session.startTransaction();
+				StateAndMetadata<R> result = formatDriver.loadAllState();
+				FormatDriver<R> newFormatDriver = detectFormat(); // TODO: use the configured driver, not the detected one
+				collection.deleteMany(new BsonDocument());
+				newFormatDriver.initializeCollection(result);
+				session.commitTransaction();
+				formatDriver = newFormatDriver;
+			} catch (UninitializedCollectionException e) {
+				throw new IOException("Unable to refurbish uninitialized database collection", e);
+			} finally {
+				if (session.hasActiveTransaction()) {
+					session.abortTransaction();
+				}
+			}
+		}
+	}
+
+	@Override
+	public void close() {
+		logDriverOperation("close");
+		isClosed = true;
+		receiver.close();
+		formatDriver.close();
+	}
+
+	private <X extends Exception, Y extends Exception> void retryIfDisconnected(Action<X, Y> action) throws X, Y {
+		try {
+			action.run();
+		} catch (DisconnectedException e) {
+			recoverFrom(e);
+			LOGGER.debug("Retrying");
+			action.run();
+		}
+	}
+
+	private interface Action<X extends Exception, Y extends Exception> {
+		void run() throws X, Y;
+	}
+
+	/**
+	 * Reinitializes {@link #receiver}, detects the database format, instantiates
+	 * the appropriate {@link FormatDriver}, and uses it to load the initial bosk state.
+	 * <p>
+	 * Caller is responsible for calling {@link #receiver}{@link ChangeEventReceiver#start() .start()}
+	 * to kick off event processing. We don't do it here because some callers need to do other things
+	 * after initialization but before any events arrive.
+	 *
+	 * @return The new root object to use, if any
+	 * @throws UninitializedCollectionException if the database or collection doesn't exist
+	 */
+	private R initializeReplication() throws UninitializedCollectionException, ReceiverInitializationException {
+		if (isClosed) {
+			LOGGER.debug("Don't initialize replication on closed driver");
+			return null;
+		}
+
+		// To "debounce" this, we create a task object that will do the initialization
+		// if required, but we actually only run one at a time. Redundant tasks will just
+		// be discarded without ever having run.
+		FutureTask<R> initTask = new FutureTask<>(() -> {
+			LOGGER.debug("Initializing replication");
+			try {
+				formatDriver = new DisconnectedDriver<>(); // Fallback in case initialization fails
+				if (receiver.initialize(new Listener())) {
+					FormatDriver<R> newDriver = detectFormat();
+					StateAndMetadata<R> result = newDriver.loadAllState();
+					newDriver.onRevisionToSkip(result.revision);
+					formatDriver = newDriver;
+					return result.state;
+				} else {
+					LOGGER.warn("Unable to fetch resume token; disconnected");
+					return null;
+				}
+			} catch (ReceiverInitializationException | IOException e) {
+				LOGGER.warn("Failed to initialize replication", e);
+				throw new TunneledCheckedException(e);
+			} finally {
+				// Clearing the map entry here allows the next initialization task to be created
+				// now that this one has completed
+				initializationInProgress.set(null);
+			}
+		});
+
+		// Use initializationInProgress to check for an existing task, and if there isn't
+		// one, use the new one we just created.
+		FutureTask<R> init = initializationInProgress.updateAndGet(x -> x == null? initTask : x);
+
+		// This either runs the task (if it's the new one we just created) or waits for the run in progress to finish.
+		init.run();
+
+		try {
+			return init.get();
+		} catch (InterruptedException e) {
+			throw new NotYetImplementedException(e);
+		} catch (ExecutionException e) {
+			// Unpacking the exception is super annoying
+			if (e.getCause() instanceof UninitializedCollectionException) {
+				throw (UninitializedCollectionException) e.getCause();
+			} else if (e.getCause() instanceof TunneledCheckedException) {
+				Exception cause = ((TunneledCheckedException) e.getCause()).getCause();
+				if (cause instanceof UninitializedCollectionException) {
+					throw (UninitializedCollectionException) cause;
+				} else if (cause instanceof ReceiverInitializationException) {
+					throw (ReceiverInitializationException)cause;
+				} else {
+					throw new NotYetImplementedException(cause);
+				}
+			} else {
+				throw new NotYetImplementedException(e);
+			}
+		}
+	}
+
+	private final class Listener implements ChangeEventListener {
+		/**
+		 * Raise your hand if you want to think about the case where a listener keeps on processing
+		 * events after an exception. Nobody? Ok, that's what I thought.
+		 */
+		volatile boolean isListening = true; // (volatile is probably overkill because all calls are on the same thread anyway)
+
+		@Override
+		public void onEvent(ChangeStreamDocument<Document> event) {
+			if (isListening) {
+				try {
+					formatDriver.onEvent(event);
+				} catch (RuntimeException e) {
+					onException(e);
+				}
+			}
+		}
+
+		@Override
+		public void onException(Exception e) {
+			isListening = false;
+			recoverFrom(e);
+		}
+	}
+
+	private FormatDriver<R> detectFormat() throws UninitializedCollectionException, UnrecognizedFormatException {
+		FindIterable<Document> result = collection.find(new BsonDocument("_id", SingleDocFormatDriver.DOCUMENT_ID));
+		try (MongoCursor<Document> cursor = result.cursor()) {
+			if (cursor.hasNext()) {
+				Long revision = cursor
+					.next()
+					.get(DocumentFields.revision.name(), 0L);
+				return newSingleDocFormatDriver(revision);
+			} else {
+				throw new UninitializedCollectionException("Document doesn't exist");
+			}
+		}
+	}
+
+	private SingleDocFormatDriver<R> newSingleDocFormatDriver(long revisionAlreadySeen) {
+		return new SingleDocFormatDriver<>(
+			bosk,
+			collection,
+			driverSettings,
+			bsonPlugin,
+			new FlushLock(driverSettings, revisionAlreadySeen),
+			downstream);
+	}
+
+	private void beginDriverOperation(String description, Object... args) {
+		if (isClosed) {
+			throw new IllegalStateException("Driver is closed");
+		}
+		logDriverOperation(description, args);
+	}
+
+	private void logDriverOperation(String description, Object... args) {
+		if (LOGGER.isDebugEnabled()) {
+			String formatString = "+[" + bosk.name() + "] " + description;
+			LOGGER.debug(formatString, args);
+		}
+	}
+
+	public static final String COLLECTION_NAME = "boskCollection";
+	private static final Logger LOGGER = LoggerFactory.getLogger(MainDriver.class);
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ReceiverInitializationException.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ReceiverInitializationException.java
@@ -1,0 +1,15 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+class ReceiverInitializationException extends Exception {
+	public ReceiverInitializationException(Throwable cause) {
+		super(cause);
+	}
+
+	public ReceiverInitializationException(String message) {
+		super(message);
+	}
+
+	public ReceiverInitializationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/SingleDocFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/SingleDocFormatDriver.java
@@ -1,0 +1,413 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import com.mongodb.client.model.changestream.UpdateDescription;
+import com.mongodb.client.result.UpdateResult;
+import com.mongodb.lang.Nullable;
+import io.vena.bosk.Bosk;
+import io.vena.bosk.BoskDriver;
+import io.vena.bosk.Entity;
+import io.vena.bosk.Identifier;
+import io.vena.bosk.Reference;
+import io.vena.bosk.drivers.mongo.BsonPlugin;
+import io.vena.bosk.drivers.mongo.MongoDriverSettings;
+import io.vena.bosk.drivers.mongo.v2.Formatter.DocumentFields;
+import io.vena.bosk.exceptions.FlushFailureException;
+import io.vena.bosk.exceptions.InvalidTypeException;
+import io.vena.bosk.exceptions.NotYetImplementedException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.bson.BsonDocument;
+import org.bson.BsonInt64;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.mongodb.client.model.Projections.fields;
+import static com.mongodb.client.model.Projections.include;
+import static io.vena.bosk.drivers.mongo.v2.Formatter.REVISION_ONE;
+import static io.vena.bosk.drivers.mongo.v2.Formatter.REVISION_ZERO;
+import static io.vena.bosk.drivers.mongo.v2.Formatter.dottedFieldNameOf;
+import static io.vena.bosk.drivers.mongo.v2.Formatter.enclosingReference;
+import static io.vena.bosk.drivers.mongo.v2.Formatter.referenceTo;
+import static java.lang.String.format;
+import static java.util.Collections.newSetFromMap;
+import static org.bson.BsonBoolean.FALSE;
+
+final class SingleDocFormatDriver<R extends Entity> implements FormatDriver<R> {
+	private final String description;
+	private final MongoDriverSettings settings;
+	private final Formatter formatter;
+	private final MongoCollection<Document> collection;
+	private final Reference<R> rootRef;
+	private final String echoPrefix;
+	private final BoskDriver<R> downstream;
+	private final FlushLock flushLock;
+
+	private volatile BsonInt64 revisionToSkip = null;
+
+	static final BsonString DOCUMENT_ID = new BsonString("boskDocument");
+
+	SingleDocFormatDriver(
+		Bosk<R> bosk,
+		MongoCollection<Document> collection,
+		MongoDriverSettings driverSettings,
+		BsonPlugin bsonPlugin,
+		FlushLock flushLock,
+		BoskDriver<R> downstream
+	) {
+		this.description = SingleDocFormatDriver.class.getSimpleName() + ": " + driverSettings;
+		this.settings = driverSettings;
+		this.formatter = new Formatter(bosk, bsonPlugin);
+		this.collection = collection;
+		this.echoPrefix = bosk.instanceID().toString();
+		this.rootRef = bosk.rootReference();
+		this.downstream = downstream;
+		this.flushLock = flushLock;
+	}
+
+	@Override
+	public <T> void submitReplacement(Reference<T> target, T newValue) {
+		doUpdate(replacementDoc(target, newValue), standardPreconditions(target));
+	}
+
+	@Override
+	public <T> void submitInitialization(Reference<T> target, T newValue) {
+		BsonDocument filter = standardPreconditions(target);
+		filter.put(dottedFieldNameOf(target, rootRef), new BsonDocument("$exists", FALSE));
+		if (doUpdate(replacementDoc(target, newValue), filter)) {
+			LOGGER.debug("| Object initialized");
+		} else {
+			LOGGER.debug("| No update");
+		}
+	}
+
+	@Override
+	public <T> void submitDeletion(Reference<T> target) {
+		if (target.path().isEmpty()) {
+			throw new IllegalArgumentException("Can't delete the root of the bosk");
+		} else {
+			doUpdate(deletionDoc(target), standardPreconditions(target));
+		}
+	}
+
+	@Override
+	public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
+		doUpdate(
+			replacementDoc(target, newValue),
+			explicitPreconditions(target, precondition, requiredValue));
+	}
+
+	@Override
+	public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
+		doUpdate(
+			deletionDoc(target),
+			explicitPreconditions(target, precondition, requiredValue));
+	}
+
+	@Override
+	public void flush() throws IOException, InterruptedException {
+		flushLock.awaitRevision(readRevisionNumber());
+		LOGGER.debug("| Flush downstream");
+		downstream.flush();
+	}
+
+	@Override
+	public void close() {
+		LOGGER.debug("+ close()");
+	}
+
+	@Override
+	public StateAndMetadata<R> loadAllState() throws IOException, UninitializedCollectionException {
+		try (MongoCursor<Document> cursor = collection.find(documentFilter()).limit(1).cursor()) {
+			Document document = cursor.next();
+			Document state = document.get(DocumentFields.state.name(), Document.class);
+			Long revision = document.getLong(DocumentFields.revision.name());
+			if (state == null) {
+				throw new IOException("No existing state in document");
+			} else {
+				R root = formatter.document2object(state, rootRef);
+				BsonInt64 rev = new BsonInt64((revision==null)? 0L : revision); // Nonexistent revision == 0
+				return new StateAndMetadata<>(root, rev);
+			}
+		} catch (NoSuchElementException e) {
+			throw new UninitializedCollectionException("No existing document", e);
+		}
+
+	}
+
+	@Override
+	public void initializeCollection(StateAndMetadata<R> contents) {
+		BsonValue initialState = formatter.object2bsonValue(contents.state, rootRef.targetType());
+		BsonInt64 newRevision = new BsonInt64(1 + contents.revision.longValue());
+		BsonDocument update = new BsonDocument("$set", initialDocument(initialState, newRevision));
+		BsonDocument filter = documentFilter();
+		UpdateOptions options = new UpdateOptions().upsert(true);
+		LOGGER.debug("** Initial tenant upsert for {}", DOCUMENT_ID);
+		LOGGER.trace("| Filter: {}", filter);
+		LOGGER.trace("| Update: {}", update);
+		LOGGER.trace("| Options: {}", options);
+		UpdateResult result = collection.updateOne(filter, update, options);
+		LOGGER.debug("| Result: {}", result);
+	}
+
+	@Override
+	public void onEvent(ChangeStreamDocument<Document> event) {
+		LOGGER.debug("# EVENT: {}", event);
+		switch (event.getOperationType()) {
+			case INSERT: case REPLACE: {
+				BsonInt64 revision = getRevisionFromFullDocumentEvent(event.getFullDocument());
+				flushLock.startedRevision(revision);
+				Document state = event.getFullDocument().get(DocumentFields.state.name(), Document.class);
+				if (state == null) {
+					throw new NotYetImplementedException("No state??");
+				}
+				R newRoot = formatter.document2object(state, rootRef);
+				downstream.submitReplacement(rootRef, newRoot);
+				flushLock.finishedRevision(revision);
+			} break;
+			case UPDATE: {
+				UpdateDescription updateDescription = event.getUpdateDescription();
+				if (updateDescription != null) {
+					BsonInt64 revision = getRevisionFromUpdateEvent(event);
+					flushLock.startedRevision(revision);
+					if (shouldNotSkip(revision)) {
+						replaceUpdatedFields(updateDescription.getUpdatedFields());
+						deleteRemovedFields(updateDescription.getRemovedFields());
+					}
+					flushLock.finishedRevision(revision);
+				}
+			} break;
+			case DELETE: {
+				LOGGER.info("Delete event ignored (id={}). Assuming the document will be created again...", event.getDocumentKey());
+			} break;
+			default: {
+				throw new NotYetImplementedException("Unknown change stream event: " + event);
+			}
+		}
+	}
+
+	private BsonInt64 getRevisionFromFullDocumentEvent(Document fullDocument) {
+		if (fullDocument == null) {
+			return null;
+		}
+		Long revision = fullDocument.getLong(DocumentFields.revision.name());
+		if (revision == null) {
+			return null;
+		} else {
+			return new BsonInt64(revision);
+		}
+	}
+
+	private static BsonInt64 getRevisionFromUpdateEvent(ChangeStreamDocument<Document> event) {
+		if (event == null) {
+			return null;
+		}
+		UpdateDescription updateDescription = event.getUpdateDescription();
+		if (updateDescription == null) {
+			return null;
+		}
+		BsonDocument updatedFields = updateDescription.getUpdatedFields();
+		if (updatedFields == null) {
+			return null;
+		}
+		return updatedFields.getInt64(DocumentFields.revision.name(), null);
+	}
+
+	@Override
+	public void onRevisionToSkip(BsonInt64 revision) {
+		revisionToSkip = revision;
+	}
+
+	//
+	// MongoDB helpers
+	//
+
+	/**
+	 * @return Non-null revision number as per the database.
+	 * If the database contains no revision number, returns {@link io.vena.bosk.drivers.mongo.v2.Formatter#REVISION_ZERO}.
+	 */
+	private BsonInt64 readRevisionNumber() throws FlushFailureException {
+		LOGGER.debug("readRevisionNumber");
+		try {
+			try (MongoCursor<Document> cursor = collection
+				.find(DOCUMENT_FILTER).limit(1)
+				.projection(fields(include(DocumentFields.revision.name())))
+				.cursor()
+			) {
+				Document doc = cursor.next();
+				Long result = doc.get(DocumentFields.revision.name(), Long.class);
+				if (result == null) {
+					// Document exists but has no revision field.
+					// In that case, newer servers (including this one) will create the
+					// the field upon initialization, and we're ok to wait for any old
+					// revision number at all.
+					LOGGER.debug("No revision field; using zero");
+					return REVISION_ZERO;
+				} else {
+					LOGGER.debug("Read revision {}", result);
+					return new BsonInt64(result);
+				}
+			}
+		} catch (NoSuchElementException e) {
+			// Document doesn't exist at all yet. We're ok to wait for any update at all.
+			LOGGER.debug("No document; using zero");
+			return REVISION_ZERO;
+		} catch (RuntimeException e) {
+			LOGGER.debug("readRevisionNumber failed", e);
+			throw new FlushFailureException(e);
+		}
+	}
+
+	private BsonDocument documentFilter() {
+		return new BsonDocument("_id", DOCUMENT_ID);
+	}
+
+	private <T> BsonDocument standardPreconditions(Reference<T> target) {
+		BsonDocument filter = documentFilter();
+		if (!target.path().isEmpty()) {
+			String enclosingObjectKey = dottedFieldNameOf(enclosingReference(target), rootRef);
+			BsonDocument condition = new BsonDocument("$type", new BsonString("object"));
+			filter.put(enclosingObjectKey, condition);
+			LOGGER.debug("| Precondition: {} {}", enclosingObjectKey, condition);
+		}
+		return filter;
+	}
+
+	private <T> BsonDocument explicitPreconditions(Reference<T> target, Reference<Identifier> preconditionRef, Identifier requiredValue) {
+		BsonDocument filter = standardPreconditions(target);
+		BsonDocument precondition = new BsonDocument("$eq", new BsonString(requiredValue.toString()));
+		filter.put(dottedFieldNameOf(preconditionRef, rootRef), precondition);
+		return filter;
+	}
+
+	private <T> BsonDocument replacementDoc(Reference<T> target, T newValue) {
+		String key = dottedFieldNameOf(target, rootRef);
+		BsonValue value = formatter.object2bsonValue(newValue, target.targetType());
+		LOGGER.debug("| Set field {}: {}", key, value);
+		return updateDoc()
+			.append("$set", new BsonDocument(key, value));
+	}
+
+	private <T> BsonDocument deletionDoc(Reference<T> target) {
+		String key = dottedFieldNameOf(target, rootRef);
+		LOGGER.debug("| Unset field {}", key);
+		return updateDoc().append("$unset", new BsonDocument(key, new BsonNull())); // Value is ignored
+	}
+
+	private BsonDocument updateDoc() {
+		return new BsonDocument("$inc", new BsonDocument(DocumentFields.revision.name(), REVISION_ONE));
+	}
+
+	private BsonDocument initialDocument(BsonValue initialState, BsonInt64 revision) {
+		BsonDocument fieldValues = new BsonDocument("_id", DOCUMENT_ID);
+
+		fieldValues.put(DocumentFields.path.name(), new BsonString("/"));
+		fieldValues.put(DocumentFields.state.name(), initialState);
+		fieldValues.put(DocumentFields.echo.name(), new BsonString(format("%s_9999", echoPrefix)));
+		fieldValues.put(DocumentFields.revision.name(), revision);
+
+		return fieldValues;
+	}
+
+	/**
+	 * @return true if something changed
+	 */
+	private boolean doUpdate(BsonDocument updateDoc, BsonDocument filter) {
+		LOGGER.debug("| Update: {}", updateDoc);
+		if (settings.testing().eventDelayMS() < 0) {
+			LOGGER.debug("| Sleeping");
+			try {
+				Thread.sleep(-settings.testing().eventDelayMS());
+			} catch (InterruptedException e) {
+				LOGGER.debug("| Interrupted");
+			}
+		}
+		LOGGER.debug("| Filter: {}", filter);
+		UpdateResult result = collection.updateOne(filter, updateDoc);
+		LOGGER.debug("| Update result: {}", result);
+		if (result.wasAcknowledged()) {
+			assert result.getMatchedCount() <= 1;
+			return result.getMatchedCount() >= 1;
+		} else {
+			LOGGER.error("Mongo write was not acknowledged.\n\tFilter: {}\n\tUpdate: {}\n\tResult: {}", filter, updateDoc, result);
+			throw new NotYetImplementedException("Mongo write was not acknowledged");
+		}
+	}
+
+	/**
+	 * Call <code>downstream.{@link BoskDriver#submitReplacement submitReplacement}</code>
+	 * for each updated field.
+	 */
+	private void replaceUpdatedFields(@Nullable BsonDocument updatedFields) {
+		if (updatedFields != null) {
+			for (Map.Entry<String, BsonValue> entry : updatedFields.entrySet()) {
+				String dottedName = entry.getKey();
+				if (dottedName.startsWith(DocumentFields.state.name())) {
+					Reference<Object> ref;
+					try {
+						ref = referenceTo(dottedName, rootRef);
+					} catch (InvalidTypeException e) {
+						logNonexistentField(dottedName, e);
+						continue;
+					}
+					LOGGER.debug("| Replace {}", ref);
+					Object replacement = formatter.bsonValue2object(entry.getValue(), ref);
+					downstream.submitReplacement(ref, replacement);
+				}
+			}
+		}
+	}
+
+	private boolean shouldNotSkip(BsonInt64 revision) {
+		return revision == null || revisionToSkip == null || revision.longValue() > revisionToSkip.longValue();
+	}
+
+	/**
+	 * Call <code>downstream.{@link BoskDriver#submitDeletion submitDeletion}</code>
+	 * for each removed field.
+	 */
+	private void deleteRemovedFields(@Nullable List<String> removedFields) {
+		if (removedFields != null) {
+			for (String dottedName : removedFields) {
+				if (dottedName.startsWith(DocumentFields.state.name())) {
+					Reference<Object> ref;
+					try {
+						ref = referenceTo(dottedName, rootRef);
+					} catch (InvalidTypeException e) {
+						logNonexistentField(dottedName, e);
+						continue;
+					}
+					LOGGER.debug("| Delete {}", ref);
+					downstream.submitDeletion(ref);
+				}
+			}
+		}
+	}
+
+	private void logNonexistentField(String dottedName, InvalidTypeException e) {
+		LOGGER.trace("Nonexistent field {}",  dottedName, e);
+		if (LOGGER.isWarnEnabled() && ALREADY_WARNED.add(dottedName)) {
+			LOGGER.warn("Ignoring updates of nonexistent field {}", dottedName);
+		}
+	}
+
+	@Override
+	public String toString() {
+		return description;
+	}
+
+	private static final Set<String> ALREADY_WARNED = newSetFromMap(new ConcurrentHashMap<>());
+	private static final BsonDocument DOCUMENT_FILTER = new BsonDocument("_id", DOCUMENT_ID);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SingleDocFormatDriver.class);
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/StateAndMetadata.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/StateAndMetadata.java
@@ -1,0 +1,11 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+import io.vena.bosk.Entity;
+import lombok.RequiredArgsConstructor;
+import org.bson.BsonInt64;
+
+@RequiredArgsConstructor
+class StateAndMetadata<R extends Entity> {
+	final R state;
+	final BsonInt64 revision;
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/UninitializedCollectionException.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/UninitializedCollectionException.java
@@ -1,0 +1,18 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+class UninitializedCollectionException extends Exception {
+	public UninitializedCollectionException() {
+	}
+
+	public UninitializedCollectionException(String message) {
+		super(message);
+	}
+
+	public UninitializedCollectionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public UninitializedCollectionException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/UnrecognizedFormatException.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/UnrecognizedFormatException.java
@@ -1,0 +1,17 @@
+package io.vena.bosk.drivers.mongo.v2;
+
+import java.io.IOException;
+
+class UnrecognizedFormatException extends IOException {
+	public UnrecognizedFormatException(String message) {
+		super(message);
+	}
+
+	public UnrecognizedFormatException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public UnrecognizedFormatException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverSpecialTest.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import lombok.Value;
+import lombok.var;
 import org.bson.BsonDocument;
 import org.bson.BsonNull;
 import org.bson.BsonString;
@@ -38,6 +39,7 @@ import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -257,6 +259,59 @@ class MongoDriverSpecialTest implements TestParameters {
 			latecomerActual = latecomerBosk.rootReference().value();
 		}
 		assertEquals(expected, latecomerActual);
+	}
+
+	@ParametersByName
+	@DisruptsMongoService
+	@Disabled("Only supported for ImplementationKind = RESILIENT")
+	void initialOutage_boskRecovers() throws InvalidTypeException, InterruptedException, IOException {
+		// Set up the database contents to be different from initialRoot
+		Bosk<TestEntity> prepBosk = new Bosk<TestEntity>(
+			"Prep bosk",
+			TestEntity.class,
+			bosk -> initialRoot(bosk).withString("distinctive string"),
+			driverFactory);
+		prepBosk.driver().flush();
+		((MongoDriver<TestEntity>)prepBosk.driver()).close();
+
+		TestEntity defaultState = initialRoot(prepBosk);
+		TestEntity mongoState = defaultState.withString("distinctive string");
+
+		mongoService.proxy().setConnectionCut(true);
+
+		Bosk<TestEntity> bosk = new Bosk<TestEntity>("Test bosk", TestEntity.class, this::initialRoot, driverFactory);
+		Refs refs = bosk.buildReferences(Refs.class);
+		BoskDriver<TestEntity> driver = bosk.driver();
+
+		try (var __ = bosk.readContext()) {
+			assertEquals(defaultState, bosk.rootReference().value(),
+				"Uses default state if database is unavailable");
+		}
+
+		assertThrows(FlushFailureException.class, driver::flush,
+			"Flush disallowed during outage");
+		assertThrows(Exception.class, () -> driver.submitReplacement(bosk.rootReference(), initialRoot(bosk)),
+			"Updates disallowed during outage");
+
+		mongoService.proxy().setConnectionCut(false);
+
+		driver.flush();
+		try (var __ = bosk.readContext()) {
+			assertEquals(mongoState, bosk.rootReference().value(),
+				"Updates to database state once it reconnects");
+		}
+
+		// Make a change to the bosk and verify that it gets through
+		driver.submitReplacement(refs.listingEntry(entity123), LISTING_ENTRY);
+		TestEntity expected = initialRoot(bosk)
+			.withString("distinctive string")
+			.withListing(Listing.of(refs.catalog(), entity123));
+
+
+		driver.flush();
+		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = bosk.readContext()) {
+			assertEquals(expected, bosk.rootReference().value());
+		}
 	}
 
 	@ParametersByName

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/TestParameters.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/TestParameters.java
@@ -14,8 +14,11 @@ public interface TestParameters {
 		String prefix = "boskTestDB_" + dbCounter.incrementAndGet();
 		return Stream.of(
 			MongoDriverSettings.builder()
-				.database(prefix + "_echo")
+				.database(prefix + "_stable")
 				.flushMode(ECHO)
+//			MongoDriverSettings.builder()
+//				.database(prefix + "_resilient")
+//				.implementationKind(RESILIENT)
 			// These tests fail too often. REVISION_FIELD_ONLY is not reliable yet.
 //			MongoDriverSettings.builder()
 //				.database(prefix + "_rev")

--- a/spotbugsExclude.xml
+++ b/spotbugsExclude.xml
@@ -14,6 +14,9 @@
 		<Bug code="RCN"/>
 	</Match>
 	<Match>
+		<Bug code="NP"/> <!-- https://github.com/spotbugs/spotbugs/issues/651 -->
+	</Match>
+	<Match>
 		<Bug code="DP"/> <!-- doPrivileged is deprecated for removal -->
 	</Match>
 	<Match>


### PR DESCRIPTION
Initial cut of a so-called `RESILIENT` version of `MongoDriver`.

This framework supports:
- A "drop everything and start over" operation that handles a wide variety of weird failure modes
- Database format detection, to allow evolution of the on-disk layout
- Database outages at initialization time
- An echo-free `flush()` implementation

Much more to come...

(Second attempt of #18, with automated tests disabled for now on the new code.)