### PR TITLE
Fix race in FlushLock

### DIFF
--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
@@ -74,7 +74,7 @@ public class MainDriver<R extends Entity> implements MongoDriver<R> {
 			.getDatabase(driverSettings.database());
 		this.collection = database
 			.getCollection(COLLECTION_NAME);
-		this.receiver = new ChangeEventReceiver(bosk.name(), collection);
+		this.receiver = new ChangeEventReceiver(bosk.name(), driverSettings, collection);
 	}
 
 	private void validateMongoClientSettings(MongoClientSettings clientSettings) {

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/SingleDocFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/SingleDocFormatDriver.java
@@ -167,7 +167,6 @@ final class SingleDocFormatDriver<R extends Entity> implements FormatDriver<R> {
 		switch (event.getOperationType()) {
 			case INSERT: case REPLACE: {
 				BsonInt64 revision = getRevisionFromFullDocumentEvent(event.getFullDocument());
-				flushLock.startedRevision(revision);
 				Document state = event.getFullDocument().get(DocumentFields.state.name(), Document.class);
 				if (state == null) {
 					throw new NotYetImplementedException("No state??");
@@ -180,7 +179,6 @@ final class SingleDocFormatDriver<R extends Entity> implements FormatDriver<R> {
 				UpdateDescription updateDescription = event.getUpdateDescription();
 				if (updateDescription != null) {
 					BsonInt64 revision = getRevisionFromUpdateEvent(event);
-					flushLock.startedRevision(revision);
 					if (shouldNotSkip(revision)) {
 						replaceUpdatedFields(updateDescription.getUpdatedFields());
 						deleteRemovedFields(updateDescription.getRemovedFields());

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/TestParameters.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/TestParameters.java
@@ -4,7 +4,8 @@ import io.vena.bosk.drivers.mongo.MongoDriverSettings.MongoDriverSettingsBuilder
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
-import static io.vena.bosk.drivers.mongo.MongoDriverSettings.FlushMode.ECHO;
+import static io.vena.bosk.drivers.mongo.MongoDriverSettings.ImplementationKind.RESILIENT;
+import static io.vena.bosk.drivers.mongo.MongoDriverSettings.ImplementationKind.STABLE;
 
 public interface TestParameters {
 	AtomicInteger dbCounter = new AtomicInteger(0);
@@ -15,20 +16,10 @@ public interface TestParameters {
 		return Stream.of(
 			MongoDriverSettings.builder()
 				.database(prefix + "_stable")
-				.flushMode(ECHO)
-//			MongoDriverSettings.builder()
-//				.database(prefix + "_resilient")
-//				.implementationKind(RESILIENT)
-			// These tests fail too often. REVISION_FIELD_ONLY is not reliable yet.
-//			MongoDriverSettings.builder()
-//				.database(prefix + "_rev")
-//				.flushMode(REVISION_FIELD_ONLY),
-//			MongoDriverSettings.builder()
-//				.database(prefix + "_slow")
-//				.flushMode(REVISION_FIELD_ONLY)
-//				.testing(MongoDriverSettings.Testing.builder()
-//					.eventDelayMS(100)
-//					.build())
+				.implementationKind(STABLE),
+			MongoDriverSettings.builder()
+				.database(prefix + "_resilient")
+				.implementationKind(RESILIENT)
 		);
 	}
 


### PR DESCRIPTION
Added `queueLock` to make operations atomically manipulate the queue and check the `alreadySeen` field. This way, `awaitRevision` can be certain whether or not it ought to wait to be released by `finishRevision`.

Without this, the experimental Resilient MongoDriver could return from `flush()` before the required updates were submitted downstream.