### PR TITLE
Resilient driver work

### DIFF
--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ChangeEventReceiver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ChangeEventReceiver.java
@@ -64,7 +64,7 @@ class ChangeEventReceiver implements Closeable {
 	private static final class Session {
 		final MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor;
 		final ChangeEventListener listener;
-		ChangeStreamDocument<Document> initialEvent;
+		ChangeStreamDocument<Document> initialEvent; // Could be final, but we want to let the GC collect it
 		volatile boolean isClosed;
 	}
 
@@ -174,7 +174,7 @@ class ChangeEventReceiver implements Closeable {
 		for (attempt = 1; attempt <= 2; attempt++) {
 			LOGGER.debug("Attempt #{}", attempt);
 			ChangeStreamDocument<Document> initialEvent;
-			BsonDocument resumePoint = null; //lastProcessedResumeToken;
+			BsonDocument resumePoint = null; // TODO: use lastProcessedResumeToken;
 			if (resumePoint == null) {
 				if (settings.testing().eventDelayMS() < 0) {
 					LOGGER.debug("- Sleeping");

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ChangeEventReceiver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ChangeEventReceiver.java
@@ -174,7 +174,10 @@ class ChangeEventReceiver implements Closeable {
 		for (attempt = 1; attempt <= 2; attempt++) {
 			LOGGER.debug("Attempt #{}", attempt);
 			ChangeStreamDocument<Document> initialEvent;
-			BsonDocument resumePoint = null; // TODO: use lastProcessedResumeToken;
+			// Resuming from lastProcessedResumeToken doesn't currently work.
+			// It is the source of a lot of race conditions, and it doesn't actually
+			// achieve anything until we use it to avoid loading the entire bosk state.
+			BsonDocument resumePoint = null; // lastProcessedResumeToken;
 			if (resumePoint == null) {
 				if (settings.testing().eventDelayMS() < 0) {
 					LOGGER.debug("- Sleeping");

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ChangeEventReceiver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/ChangeEventReceiver.java
@@ -209,7 +209,7 @@ class ChangeEventReceiver implements Closeable {
 			}
 			try {
 				MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor
-					= collection.watch().resumeAfter(resumePoint).cursor();
+					= collection.watch().startAfter(resumePoint).cursor();
 				currentSession = new Session(cursor, newListener, initialEvent, false);
 				return true;
 			} catch (MongoCommandException e) {

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/DisconnectedDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/DisconnectedDriver.java
@@ -54,7 +54,7 @@ class DisconnectedDriver<R extends Entity> implements FormatDriver<R> {
 	}
 
 	@Override
-	public void initializeCollection(StateAndMetadata<R> contents) {
+	public void initializeCollection(StateAndMetadata<R> priorContents) {
 
 	}
 

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FlushLock.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FlushLock.java
@@ -65,11 +65,10 @@ class FlushLock implements Closeable {
 			if (isClosed) {
 				throw new FlushFailureException("Wait aborted");
 			}
+			LOGGER.debug("Done awaiting revision {}", revisionValue);
 		} else {
 			LOGGER.debug("Revision {} <= {} is in the past; don't wait", revisionValue, past);
-			return;
 		}
-		LOGGER.trace("Done awaiting revision {}", revisionValue);
 	}
 
 	/**

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FormatDriver.java
@@ -44,11 +44,24 @@ interface FormatDriver<R extends Entity> extends MongoDriver<R> {
 	 */
 	void onRevisionToSkip(BsonInt64 revision);
 
+	/**
+	 * @throws UninitializedCollectionException if it looks like the database has not yet
+	 * been created (as opposed to being in a damaged or unrecognizable state).
+	 * This signals to {@link MainDriver} that it may, if appropriate,
+	 * automatically initialize the collection.
+	 * @throws IOException if otherwise unable to return the appropriate result.
+	 */
 	StateAndMetadata<R> loadAllState() throws IOException, UninitializedCollectionException;
 
 	/**
-	 * Can assume that the collection is empty or nonexistent.
-	 * Can assume it's called in a transaction.
+	 * Can assume there is an active database transaction.
+	 * <p>
+	 * Can assume that the collection is empty or nonexistent,
+	 * in the sense that there is no mess to clean up,
+	 * but should tolerate documents already existing,
+	 * by using upsert or replace operations, for example.
+	 * @param contents the state and metadata to use.
+	 * In particular, the revision number can be used directly without being incremented.
 	 */
 	void initializeCollection(StateAndMetadata<R> contents) throws InitializationFailureException;
 

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FormatDriver.java
@@ -60,10 +60,10 @@ interface FormatDriver<R extends Entity> extends MongoDriver<R> {
 	 * in the sense that there is no mess to clean up,
 	 * but should tolerate documents already existing,
 	 * by using upsert or replace operations, for example.
-	 * @param contents the state and metadata to use.
-	 * In particular, the revision number can be used directly without being incremented.
+	 * @param priorContents the desired state, with metadata representing a (possibly hypothetical)
+	 * "prior" state of the database; in particular, the revision number should be incremented.
 	 */
-	void initializeCollection(StateAndMetadata<R> contents) throws InitializationFailureException;
+	void initializeCollection(StateAndMetadata<R> priorContents) throws InitializationFailureException;
 
 	@Override
 	default R initialRoot(Type rootType) {

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/FormatDriver.java
@@ -20,7 +20,7 @@ import org.bson.Document;
  * </li><li>
  *     Processing change stream events via {@link #onEvent}
  * </li><li>
- *     Managing revision numbers (eg. {@link #onRevisionToSkip}
+ *     Managing revision numbers (eg. {@link #onRevisionToSkip})
  * </li><li>
  *     Implementing {@link #flush()} (consider using {@link FlushLock})
  * </li></ol>
@@ -49,7 +49,6 @@ interface FormatDriver<R extends Entity> extends MongoDriver<R> {
 	 * been created (as opposed to being in a damaged or unrecognizable state).
 	 * This signals to {@link MainDriver} that it may, if appropriate,
 	 * automatically initialize the collection.
-	 * @throws IOException if otherwise unable to return the appropriate result.
 	 */
 	StateAndMetadata<R> loadAllState() throws IOException, UninitializedCollectionException;
 

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
@@ -261,7 +261,7 @@ public class MainDriver<R extends Entity> implements MongoDriver<R> {
 				action.run();
 			} catch (RuntimeException e) {
 				recoverFrom(e);
-				LOGGER.debug("Retrying");
+				LOGGER.debug("Retrying " + description, args);
 				action.run();
 			}
 		}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
@@ -156,7 +156,7 @@ public class MainDriver<R extends Entity> implements MongoDriver<R> {
 				LOGGER.warn("Collection is uninitialized; driver is disconnected", e);
 				return;
 			} catch (IOException | ReceiverInitializationException e) {
-				LOGGER.warn("Unable to initialize receiver", e);
+				LOGGER.warn("Unable to initialize event receiver", e);
 				return;
 			}
 			if (result != null) {
@@ -276,7 +276,7 @@ public class MainDriver<R extends Entity> implements MongoDriver<R> {
 		}
 	}
 
-	private <X extends Exception, Y extends Exception> void runWithRetry(Action<X, Y> action, String description, Object... args) throws X, Y {
+	private <X extends Exception> void runWithRetry(Action<X> action, String description, Object... args) throws X {
 		try (MDCScope __ = beginDriverOperation(description, args)) {
 			try {
 				action.run();
@@ -298,8 +298,8 @@ public class MainDriver<R extends Entity> implements MongoDriver<R> {
 		}
 	}
 
-	private interface Action<X extends Exception, Y extends Exception> {
-		void run() throws X, Y;
+	private interface Action<X extends Exception> {
+		void run() throws X;
 	}
 
 	/**

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
@@ -39,6 +39,7 @@ import org.slf4j.MDC;
 
 import static io.vena.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SINGLE_DOC;
 import static io.vena.bosk.drivers.mongo.v2.Formatter.REVISION_ONE;
+import static io.vena.bosk.drivers.mongo.v2.Formatter.REVISION_ZERO;
 
 /**
  * Serves as a harness for driver implementations.
@@ -236,7 +237,7 @@ public class MainDriver<R extends Entity> implements MongoDriver<R> {
 			.build();
 		try (ClientSession session = mongoClient.startSession(sessionOptions)) {
 			try {
-				newDriver.initializeCollection(new StateAndMetadata<>(result, REVISION_ONE));
+				newDriver.initializeCollection(new StateAndMetadata<>(result, REVISION_ZERO));
 			} finally {
 				if (session.hasActiveTransaction()) {
 					session.abortTransaction();

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/MainDriver.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import static io.vena.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SINGLE_DOC;
-import static io.vena.bosk.drivers.mongo.v2.Formatter.REVISION_ONE;
 import static io.vena.bosk.drivers.mongo.v2.Formatter.REVISION_ZERO;
 
 /**
@@ -132,7 +131,7 @@ public class MainDriver<R extends Entity> implements MongoDriver<R> {
 
 	private FormatDriver<R> newPreferredFormatDriver() {
 		if (driverSettings.preferredDatabaseFormat() == SINGLE_DOC) {
-			return newSingleDocFormatDriver(REVISION_ONE.longValue());
+			return newSingleDocFormatDriver(REVISION_ZERO.longValue());
 		} else {
 			throw new AssertionError("Unknown database format setting: " + driverSettings.preferredDatabaseFormat());
 		}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/SingleDocFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/v2/SingleDocFormatDriver.java
@@ -146,9 +146,9 @@ final class SingleDocFormatDriver<R extends Entity> implements FormatDriver<R> {
 	}
 
 	@Override
-	public void initializeCollection(StateAndMetadata<R> contents) {
-		BsonValue initialState = formatter.object2bsonValue(contents.state, rootRef.targetType());
-		BsonInt64 newRevision = new BsonInt64(1 + contents.revision.longValue());
+	public void initializeCollection(StateAndMetadata<R> priorContents) {
+		BsonValue initialState = formatter.object2bsonValue(priorContents.state, rootRef.targetType());
+		BsonInt64 newRevision = new BsonInt64(1 + priorContents.revision.longValue());
 		BsonDocument update = new BsonDocument("$set", initialDocument(initialState, newRevision));
 		BsonDocument filter = documentFilter();
 		UpdateOptions options = new UpdateOptions().upsert(true);

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverResiliencyTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverResiliencyTest.java
@@ -112,25 +112,25 @@ public class MongoDriverResiliencyTest extends AbstractMongoDriverTest {
 
 	@ParametersByName
 	@UsesMongoService
-	void databaseDeleted_recovers() throws InvalidTypeException, InterruptedException, IOException {
+	void databaseDropped_recovers() throws InvalidTypeException, InterruptedException, IOException {
 		testRecovery(() -> {
 			LOGGER.debug("Drop database");
 			mongoService.client()
 				.getDatabase(driverSettings.database())
 				.drop();
-		}, (b) -> initializeDatabase("after deletion"));
+		}, (b) -> initializeDatabase("after drop"));
 	}
 
 	@ParametersByName
 	@UsesMongoService
-	void collectionDeleted_recovers() throws InvalidTypeException, InterruptedException, IOException {
+	void collectionDropped_recovers() throws InvalidTypeException, InterruptedException, IOException {
 		testRecovery(() -> {
 			LOGGER.debug("Drop collection");
 			mongoService.client()
 				.getDatabase(driverSettings.database())
 				.getCollection(COLLECTION_NAME)
 				.drop();
-		}, (b) -> initializeDatabase("after deletion"));
+		}, (b) -> initializeDatabase("after drop"));
 	}
 
 	@ParametersByName

--- a/lib-testing/src/main/resources/logback.xml
+++ b/lib-testing/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%d %-5level [%thread] %logger{25}: %msg%n</pattern>
+			<pattern>%d %-5level [%thread]%X{MongoDriver} %logger{25}: %msg%n</pattern>
 		</encoder>
 		<immediateFlush>true</immediateFlush>
 	</appender>


### PR DESCRIPTION
Some refactoring, some logging improvements, and several fixes:

- Always do database initialization inside a transaction
- Use revision=1 instead of 2 when initializing
- Some resume token changes that don't matter because we're not currently using resume tokens anyway:
  - Use the MongoDB `startAfter` API instead of `resumeAfter` in order to support `INVALIDATE` events
  - Discard resume token on some "hopeless" events, where a new `FormatDriver` can't possibly respond to those events anyway