### PR TITLE
Switch to resilient MongoDriver by default

### DIFF
--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
@@ -23,7 +23,7 @@ public class MongoDriverSettings {
 	@Value
 	@Builder
 	public static class Experimental {
-		@Default ImplementationKind implementationKind = ImplementationKind.STABLE;
+		@Default ImplementationKind implementationKind = ImplementationKind.RESILIENT;
 		@Default FlushMode flushMode = FlushMode.ECHO;
 		@Default long changeStreamInitialWaitMS = 20;
 	}


### PR DESCRIPTION
Old behaviour can be restored by configuring your `MongoDriverSettings` like this:

```
MongoDriverSettings.builder()
  .experimental(Experimental.builder()
    .implementationKind(STABLE)
    .build())
  .build()
```