### PR TITLE
Add default ossrhUsername and ossrhPassword

### DIFF
--- a/buildSrc/src/main/groovy/bosk.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/bosk.maven-publish.gradle
@@ -73,8 +73,8 @@ publishing {
 			url version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
 			credentials {
-				username ossrhUsername
-				password ossrhPassword
+				username = project.properties['ossrhUsername'] ?: 'bogusUser'
+				password = project.properties['ossrhPassword'] ?: 'bogusPassword'
 			}
 		}
 	}


### PR DESCRIPTION
Fix for https://github.com/venasolutions/bosk/issues/23.

Checks for `ossrhUsername` and `ossrhPassword` properties and assigns bogus, default values for them. 