### PR TITLE
MongoDriver liveness

### DIFF
--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
@@ -12,6 +12,7 @@ public class MongoDriverSettings {
 	String database;
 
 	@Default long flushTimeoutMS = 30_000;
+	@Default long recoveryPollingMS = 30_000;
 	@Default DatabaseFormat preferredDatabaseFormat = DatabaseFormat.SINGLE_DOC;
 
 	@Default Experimental experimental = Experimental.builder().build();

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverResiliencyTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverResiliencyTest.java
@@ -48,15 +48,18 @@ public class MongoDriverResiliencyTest extends AbstractMongoDriverTest {
 		return Stream.of(
 			MongoDriverSettings.builder()
 				.database("boskResiliencyTestDB_" + dbCounter.incrementAndGet())
+				.recoveryPollingMS(500)
 				.experimental(resilient),
 			MongoDriverSettings.builder()
 				.database("boskResiliencyTestDB_" + dbCounter.incrementAndGet() + "_late")
+				.recoveryPollingMS(500)
 				.experimental(resilient)
 				.testing(MongoDriverSettings.Testing.builder()
 					.eventDelayMS(200)
 					.build()),
 			MongoDriverSettings.builder()
 				.database("boskResiliencyTestDB_" + dbCounter.incrementAndGet() + "_early")
+				.recoveryPollingMS(500)
 				.experimental(resilient)
 				.testing(MongoDriverSettings.Testing.builder()
 					.eventDelayMS(-200)


### PR DESCRIPTION
Without this fix, if `MainDriver` loses connectivity, it will stop updating the in-memory state until the next `BoskDriver` method call. In some applications, this could take an unlimited time; in fact, some applications might not call the driver ever.

It turned out to be pretty easy to add a background task that periodically reconnects if it finds the driver has been disconnected.

We unit test this by changing almost all `flush()` calls to `sleep`s.

Fixes #27 