### PR TITLE
Revert "Switch to resilient MongoDriver by default"

### DIFF
--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
@@ -24,7 +24,7 @@ public class MongoDriverSettings {
 	@Value
 	@Builder
 	public static class Experimental {
-		@Default ImplementationKind implementationKind = ImplementationKind.RESILIENT;
+		@Default ImplementationKind implementationKind = ImplementationKind.STABLE;
 		@Default FlushMode flushMode = FlushMode.ECHO;
 		@Default long changeStreamInitialWaitMS = 20;
 	}


### PR DESCRIPTION
Reverts venasolutions/bosk#26.

I initially enabled it by default because I felt it was the best I could do, but I've had new ideas in #32, so let's leave the default as-is for now.