### PR TITLE
Use "v3" resilient driver by default

### DIFF
--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
@@ -25,7 +25,7 @@ public class MongoDriverSettings {
 	@Value
 	@Builder
 	public static class Experimental {
-		@Default ImplementationKind implementationKind = ImplementationKind.STABLE;
+		@Default ImplementationKind implementationKind = ImplementationKind.RESILIENT;
 		@Default FlushMode flushMode = FlushMode.ECHO;
 		@Default long changeStreamInitialWaitMS = 20;
 	}


### PR DESCRIPTION
At this point, the `RESILIENT` driver is very likely more reliable than the `STABLE` driver. It's time to switch the default.