### PR TITLE
bosk-jackson fixes

### DIFF
--- a/bosk-jackson/build.gradle
+++ b/bosk-jackson/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-	api 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+	api 'com.fasterxml.jackson.core:jackson-databind:2.15.1'
 	api project(":bosk-core")
 
 	testImplementation project(":lib-testing")

--- a/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
@@ -723,7 +723,8 @@ public final class JacksonPlugin extends SerializationPlugin {
 	 * Returns the fields present in the JSON, with value objects deserialized
 	 * using type information from <code>parametersByName</code>.
 	 */
-	public Map<String, Object> gatherParameterValuesByName(Class<?> nodeClass, Map<String, Parameter> parametersByName, FieldModerator moderator, JsonParser p, DeserializationContext ctxt) throws IOException {
+	public Map<String, Object> gatherParameterValuesByName(JavaType nodeJavaType, Map<String, Parameter> parametersByName, FieldModerator moderator, JsonParser p, DeserializationContext ctxt) throws IOException {
+		Class<?> nodeClass = nodeJavaType.getRawClass();
 		Map<String, Object> parameterValuesByName = new HashMap<>();
 		expect(START_OBJECT, p);
 		while (p.nextToken() != END_OBJECT) {
@@ -733,7 +734,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 			if (parameter == null) {
 				throw new JsonParseException(p, "No such parameter in constructor for " + nodeClass.getSimpleName() + ": " + name);
 			} else {
-				JavaType parameterType = TypeFactory.defaultInstance().constructType(parameter.getParameterizedType());
+				JavaType parameterType = TypeFactory.defaultInstance().resolveMemberType(parameter.getParameterizedType(), nodeJavaType.getBindings());
 				Object deserializedValue;
 				try (@SuppressWarnings("unused") DeserializationScope scope = nodeFieldDeserializationScope(nodeClass, name)) {
 					deserializedValue = readField(name, p, ctxt, parameterType, moderator);

--- a/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
@@ -108,17 +108,17 @@ public final class JacksonPlugin extends SerializationPlugin {
 			if (theClass.isAnnotationPresent(DerivedRecord.class)) {
 				return derivedRecordSerializer(config, type, beanDesc);
 			} else if (Catalog.class.isAssignableFrom(theClass)) {
-				return catalogSerializer(config, type, beanDesc);
+				return catalogSerializer(config, beanDesc);
 			} else if (Listing.class.isAssignableFrom(theClass)) {
-				return listingSerializer(config, type, beanDesc);
+				return listingSerializer(config, beanDesc);
 			} else if (Reference.class.isAssignableFrom(theClass)) {
-				return referenceSerializer(config, type, beanDesc);
+				return referenceSerializer(config, beanDesc);
 			} else if (Identifier.class.isAssignableFrom(theClass)) {
-				return identifierSerializer(config, type, beanDesc);
+				return identifierSerializer(config, beanDesc);
 			} else if (ListingEntry.class.isAssignableFrom(theClass)) {
-				return listingEntrySerializer(config, type, beanDesc);
+				return listingEntrySerializer(config, beanDesc);
 			} else if (SideTable.class.isAssignableFrom(theClass)) {
-				return sideTableSerializer(config, type, beanDesc);
+				return sideTableSerializer(config, beanDesc);
 			} else if (StateTreeNode.class.isAssignableFrom(theClass)) {
 				return stateTreeNodeSerializer(config, type, beanDesc);
 			} else if (Optional.class.isAssignableFrom(theClass)) {
@@ -127,7 +127,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 			} else if (Phantom.class.isAssignableFrom(theClass)) {
 				throw new IllegalArgumentException("Cannot serialize a Phantom on its own; only as a field of another object");
 			} else if (MapValue.class.isAssignableFrom(theClass)) {
-				return mapValueSerializer(config, type, beanDesc);
+				return mapValueSerializer(config, beanDesc);
 			} else {
 				return null;
 			}
@@ -137,7 +137,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 			return derivedRecordSerDes(type, beanDesc, bosk).serializer(config);
 		}
 
-		private JsonSerializer<Catalog<Entity>> catalogSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+		private JsonSerializer<Catalog<Entity>> catalogSerializer(SerializationConfig config, BeanDescription beanDesc) {
 			return new JsonSerializer<Catalog<Entity>>() {
 				@Override
 				public void serialize(Catalog<Entity> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
@@ -146,7 +146,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 			};
 		}
 
-		private JsonSerializer<Listing<Entity>> listingSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+		private JsonSerializer<Listing<Entity>> listingSerializer(SerializationConfig config, BeanDescription beanDesc) {
 			return new JsonSerializer<Listing<Entity>>() {
 				@Override
 				public void serialize(Listing<Entity> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
@@ -167,7 +167,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 			};
 		}
 
-		private JsonSerializer<Reference<?>> referenceSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+		private JsonSerializer<Reference<?>> referenceSerializer(SerializationConfig config, BeanDescription beanDesc) {
 			return new JsonSerializer<Reference<?>>() {
 				@Override
 				public void serialize(Reference<?> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
@@ -176,7 +176,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 			};
 		}
 
-		private JsonSerializer<Identifier> identifierSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+		private JsonSerializer<Identifier> identifierSerializer(SerializationConfig config, BeanDescription beanDesc) {
 			return new JsonSerializer<Identifier>() {
 				@Override
 				public void serialize(Identifier value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
@@ -185,7 +185,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 			};
 		}
 
-		private JsonSerializer<ListingEntry> listingEntrySerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+		private JsonSerializer<ListingEntry> listingEntrySerializer(SerializationConfig config, BeanDescription beanDesc) {
 			// We serialize ListingEntry as a boolean `true` with the following rationale:
 			// - The only "unit type" in JSON is null
 			// - `null` is not suitable because many systems treat that as being equivalent to an absent field
@@ -201,7 +201,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 			};
 		}
 
-		private JsonSerializer<SideTable<Entity, Object>> sideTableSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+		private JsonSerializer<SideTable<Entity, Object>> sideTableSerializer(SerializationConfig config, BeanDescription beanDesc) {
 			return new JsonSerializer<SideTable<Entity, Object>>() {
 				@Override
 				public void serialize(SideTable<Entity, Object> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
@@ -225,8 +225,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 			return compiler.<StateTreeNode>compiled(type, bosk, moderator).serializer(config);
 		}
 
-		private JsonSerializer<MapValue<Object>> mapValueSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
-			JavaType valueType = mapValueValueType(type);
+		private JsonSerializer<MapValue<Object>> mapValueSerializer(SerializationConfig config, BeanDescription beanDesc) {
 			return new JsonSerializer<MapValue<Object>>() {
 				@Override
 				public void serialize(MapValue<Object> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {

--- a/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
@@ -145,8 +145,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 			return new JsonSerializer<Catalog<Entity>>() {
 				@Override
 				public void serialize(Catalog<Entity> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-					JsonSerializer valueSerializer = serializers.findContentValueSerializer(entryType, null);
-					writeMapEntries(gen, value.asMap().entrySet(), valueSerializer, serializers);
+					writeMapEntries(gen, value.asMap().entrySet(), entryType, serializers);
 				}
 			};
 		}
@@ -214,9 +213,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 					gen.writeStartObject();
 
 					gen.writeFieldName("valuesById");
-					@SuppressWarnings("unchecked")
-					JsonSerializer<Object> contentValueSerializer = (JsonSerializer<Object>) serializers.findContentValueSerializer(valueType, null);
-					writeMapEntries(gen, value.idEntrySet(), contentValueSerializer, serializers);
+					writeMapEntries(gen, value.idEntrySet(), valueType, serializers);
 
 					gen.writeFieldName("domain");
 					serializers
@@ -532,7 +529,8 @@ public final class JacksonPlugin extends SerializationPlugin {
 		@Override public boolean isCachable() { return true; }
 	}
 
-	private <V> void writeMapEntries(JsonGenerator gen, Set<Entry<Identifier,V>> entries, JsonSerializer<V> valueSerializer, SerializerProvider serializers) throws IOException {
+	private <V> void writeMapEntries(JsonGenerator gen, Set<Entry<Identifier,V>> entries, JavaType entryType, SerializerProvider serializers) throws IOException {
+		JsonSerializer<Object> valueSerializer = serializers.findContentValueSerializer(entryType, null);
 		gen.writeStartArray();
 		for (Entry<Identifier, V> entry: entries) {
 			gen.writeStartObject();

--- a/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
@@ -248,10 +248,10 @@ public final class JacksonPlugin extends SerializationPlugin {
 			return new JsonSerializer<MapValue<Object>>() {
 				@Override
 				public void serialize(MapValue<Object> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-					JsonSerializer<Object> valueSerializer = serializers.findValueSerializer(valueType);
 					gen.writeStartObject();
 					for (Entry<String, Object> element : value.entrySet()) {
 						gen.writeFieldName(requireNonNull(element.getKey()));
+						JsonSerializer<Object> valueSerializer = serializers.findValueSerializer(valueType);
 						valueSerializer.serialize(requireNonNull(element.getValue()), gen, serializers);
 					}
 					gen.writeEndObject();
@@ -530,11 +530,11 @@ public final class JacksonPlugin extends SerializationPlugin {
 	}
 
 	private <V> void writeMapEntries(JsonGenerator gen, Set<Entry<Identifier,V>> entries, JavaType entryType, SerializerProvider serializers) throws IOException {
-		JsonSerializer<Object> valueSerializer = serializers.findContentValueSerializer(entryType, null);
 		gen.writeStartArray();
 		for (Entry<Identifier, V> entry: entries) {
 			gen.writeStartObject();
 			gen.writeFieldName(entry.getKey().toString());
+			JsonSerializer<Object> valueSerializer = serializers.findContentValueSerializer(entryType, null);
 			valueSerializer.serialize(entry.getValue(), gen, serializers);
 			gen.writeEndObject();
 		}

--- a/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
@@ -106,33 +106,73 @@ public final class JacksonPlugin extends SerializationPlugin {
 		public JsonSerializer<?> findSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
 			Class theClass = type.getRawClass();
 			if (theClass.isAnnotationPresent(DerivedRecord.class)) {
-				return derivedRecordSerDes(type, beanDesc, bosk).serializer(config);
+				return derivedRecordSerializer(config, type, beanDesc);
 			} else if (Catalog.class.isAssignableFrom(theClass)) {
-				return catalogSerDes(type, beanDesc, bosk).serializer(config);
+				return catalogSerializer(config, type, beanDesc);
 			} else if (Listing.class.isAssignableFrom(theClass)) {
-				return listingSerDes(type, beanDesc, bosk).serializer(config);
+				return listingSerializer(config, type, beanDesc);
 			} else if (Reference.class.isAssignableFrom(theClass)) {
-				return referenceSerDes(type, beanDesc, bosk).serializer(config);
+				return referenceSerializer(config, type, beanDesc);
 			} else if (Identifier.class.isAssignableFrom(theClass)) {
-				return identifierSerDes(type, beanDesc, bosk).serializer(config);
+				return identifierSerializer(config, type, beanDesc);
 			} else if (ListingEntry.class.isAssignableFrom(theClass)) {
-				return listingEntrySerDes(type, beanDesc, bosk).serializer(config);
+				return listingEntrySerializer(config, type, beanDesc);
 			} else if (SideTable.class.isAssignableFrom(theClass)) {
-				return sideTableSerDes(type, beanDesc, bosk).serializer(config);
+				return sideTableSerializer(config, type, beanDesc);
 			} else if (StateTreeNode.class.isAssignableFrom(theClass)) {
-				return stateTreeNodeSerDes(type, beanDesc, bosk).serializer(config);
+				return stateTreeNodeSerializer(config, type, beanDesc);
 			} else if (Optional.class.isAssignableFrom(theClass)) {
 				// Optional.empty() can't be serialized on its own because the field name itself must also be omitted
 				throw new IllegalArgumentException("Cannot serialize an Optional on its own; only as a field of another object");
 			} else if (Phantom.class.isAssignableFrom(theClass)) {
 				throw new IllegalArgumentException("Cannot serialize a Phantom on its own; only as a field of another object");
 			} else if (ListValue.class.isAssignableFrom(theClass)) {
-				return listValueSerDes(type, beanDesc, bosk).serializer(config);
+				return listValueSerializer(config, type, beanDesc);
 			} else if (MapValue.class.isAssignableFrom(theClass)) {
-				return mapValueSerDes(type, beanDesc, bosk).serializer(config);
+				return mapValueSerializer(config, type, beanDesc);
 			} else {
 				return null;
 			}
+		}
+
+		private JsonSerializer<Object> derivedRecordSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+			return derivedRecordSerDes(type, beanDesc, bosk).serializer(config);
+		}
+
+		private JsonSerializer<Catalog<Entity>> catalogSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+			return catalogSerDes(type, beanDesc, bosk).serializer(config);
+		}
+
+		private JsonSerializer<Listing<Entity>> listingSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+			return listingSerDes(type, beanDesc, bosk).serializer(config);
+		}
+
+		private JsonSerializer<Reference<?>> referenceSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+			return referenceSerDes(type, beanDesc, bosk).serializer(config);
+		}
+
+		private JsonSerializer<Identifier> identifierSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+			return identifierSerDes(type, beanDesc, bosk).serializer(config);
+		}
+
+		private JsonSerializer<ListingEntry> listingEntrySerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+			return listingEntrySerDes(type, beanDesc, bosk).serializer(config);
+		}
+
+		private JsonSerializer<SideTable<Entity, Object>> sideTableSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+			return sideTableSerDes(type, beanDesc, bosk).serializer(config);
+		}
+
+		private JsonSerializer<StateTreeNode> stateTreeNodeSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+			return stateTreeNodeSerDes(type, beanDesc, bosk).serializer(config);
+		}
+
+		private JsonSerializer<ListValue<Object>> listValueSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+			return listValueSerDes(type, beanDesc, bosk).serializer(config);
+		}
+
+		private JsonSerializer<MapValue<Object>> mapValueSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+			return mapValueSerDes(type, beanDesc, bosk).serializer(config);
 		}
 
 		// Thanks but no thanks, Jackson. We don't need your help.
@@ -160,33 +200,73 @@ public final class JacksonPlugin extends SerializationPlugin {
 		public JsonDeserializer<?> findBeanDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
 			Class theClass = type.getRawClass();
 			if (theClass.isAnnotationPresent(DerivedRecord.class)) {
-				return derivedRecordSerDes(type, beanDesc, bosk).deserializer(config);
+				return derivedRecordDeserializer(type, config, beanDesc);
 			} else if (Catalog.class.isAssignableFrom(theClass)) {
-				return catalogSerDes(type, beanDesc, bosk).deserializer(config);
+				return catalogDeserializer(type, config, beanDesc);
 			} else if (Listing.class.isAssignableFrom(theClass)) {
-				return listingSerDes(type, beanDesc, bosk).deserializer(config);
+				return listingDeserializer(type, config, beanDesc);
 			} else if (Reference.class.isAssignableFrom(theClass)) {
-				return referenceSerDes(type, beanDesc, bosk).deserializer(config);
+				return referenceDeserializer(type, config, beanDesc);
 			} else if (Identifier.class.isAssignableFrom(theClass)) {
-				return identifierSerDes(type, beanDesc, bosk).deserializer(config);
+				return identifierDeserialier(type, config, beanDesc);
 			} else if (ListingEntry.class.isAssignableFrom(theClass)) {
-				return listingEntrySerDes(type, beanDesc, bosk).deserializer(config);
+				return listingEntryDeserializer(type, config, beanDesc);
 			} else if (SideTable.class.isAssignableFrom(theClass)) {
-				return sideTableSerDes(type, beanDesc, bosk).deserializer(config);
+				return sideTableDeserializer(type, config, beanDesc);
 			} else if (StateTreeNode.class.isAssignableFrom(theClass)) {
-				return stateTreeNodeSerDes(type, beanDesc, bosk).deserializer(config);
+				return stateTreeNodeDeserializer(type, config, beanDesc);
 			} else if (Optional.class.isAssignableFrom(theClass)) {
 				// Optional.empty() can't be serialized on its own because the field name itself must also be omitted
 				throw new IllegalArgumentException("Cannot serialize an Optional on its own; only as a field of another object");
 			} else if (Phantom.class.isAssignableFrom(theClass)) {
 				throw new IllegalArgumentException("Cannot serialize a Phantom on its own; only as a field of another object");
 			} else if (ListValue.class.isAssignableFrom(theClass)) {
-				return listValueSerDes(type, beanDesc, bosk).deserializer(config);
+				return listValueDeserializer(type, config, beanDesc);
 			} else if (MapValue.class.isAssignableFrom(theClass)) {
-				return mapValueSerDes(type, beanDesc, bosk).deserializer(config);
+				return mapValueDeserializer(type, config, beanDesc);
 			} else {
 				return null;
 			}
+		}
+
+		private JsonDeserializer<Object> derivedRecordDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
+			return derivedRecordSerDes(type, beanDesc, bosk).deserializer(config);
+		}
+
+		private JsonDeserializer<Catalog<Entity>> catalogDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
+			return catalogSerDes(type, beanDesc, bosk).deserializer(config);
+		}
+
+		private JsonDeserializer<Listing<Entity>> listingDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
+			return listingSerDes(type, beanDesc, bosk).deserializer(config);
+		}
+
+		private JsonDeserializer<Reference<?>> referenceDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
+			return referenceSerDes(type, beanDesc, bosk).deserializer(config);
+		}
+
+		private JsonDeserializer<Identifier> identifierDeserialier(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
+			return identifierSerDes(type, beanDesc, bosk).deserializer(config);
+		}
+
+		private JsonDeserializer<ListingEntry> listingEntryDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
+			return listingEntrySerDes(type, beanDesc, bosk).deserializer(config);
+		}
+
+		private JsonDeserializer<SideTable<Entity, Object>> sideTableDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
+			return sideTableSerDes(type, beanDesc, bosk).deserializer(config);
+		}
+
+		private JsonDeserializer<StateTreeNode> stateTreeNodeDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
+			return stateTreeNodeSerDes(type, beanDesc, bosk).deserializer(config);
+		}
+
+		private JsonDeserializer<ListValue<Object>> listValueDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
+			return listValueSerDes(type, beanDesc, bosk).deserializer(config);
+		}
+
+		private JsonDeserializer<MapValue<Object>> mapValueDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
+			return mapValueSerDes(type, beanDesc, bosk).deserializer(config);
 		}
 
 		// Thanks but no thanks, Jackson. We don't need your help.

--- a/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
@@ -126,8 +126,6 @@ public final class JacksonPlugin extends SerializationPlugin {
 				throw new IllegalArgumentException("Cannot serialize an Optional on its own; only as a field of another object");
 			} else if (Phantom.class.isAssignableFrom(theClass)) {
 				throw new IllegalArgumentException("Cannot serialize a Phantom on its own; only as a field of another object");
-			} else if (ListValue.class.isAssignableFrom(theClass)) {
-				return listValueSerializer(config, type, beanDesc);
 			} else if (MapValue.class.isAssignableFrom(theClass)) {
 				return mapValueSerializer(config, type, beanDesc);
 			} else {
@@ -228,19 +226,6 @@ public final class JacksonPlugin extends SerializationPlugin {
 		private JsonSerializer<StateTreeNode> stateTreeNodeSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
 			StateTreeNodeFieldModerator moderator = new StateTreeNodeFieldModerator(type);
 			return compiler.<StateTreeNode>compiled(type, bosk, moderator).serializer(config);
-		}
-
-		private JsonSerializer<ListValue<Object>> listValueSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
-			JavaType listType = listValueEquivalentListType(type);
-			return new JsonSerializer<ListValue<Object>>() {
-				@Override
-				public void serialize(ListValue<Object> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-					// Note that a ListValue<String> can actually contain an Object[],
-					// which Jackson won't serialize as a String[], so we can't use arrayType.
-					serializers.findValueSerializer(listType, null)
-						.serialize(value, gen, serializers);
-				}
-			};
 		}
 
 		private JsonSerializer<MapValue<Object>> mapValueSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
@@ -789,10 +774,6 @@ public final class JacksonPlugin extends SerializationPlugin {
 
 	private static JavaType sideTableValueType(JavaType sideTableType) {
 		return javaParameterType(sideTableType, SideTable.class, 1);
-	}
-
-	private static JavaType listValueEquivalentListType(JavaType listValueType) {
-		return TypeFactory.defaultInstance().constructCollectionType(List.class, javaParameterType(listValueType, ListValue.class, 0));
 	}
 
 	private static JavaType listValueEquivalentArrayType(JavaType listValueType) {

--- a/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
@@ -144,7 +144,6 @@ public final class JacksonPlugin extends SerializationPlugin {
 
 			return new JsonSerializer<Catalog<Entity>>() {
 				@Override
-				@SuppressWarnings({"rawtypes", "unchecked"})
 				public void serialize(Catalog<Entity> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
 					JsonSerializer valueSerializer = serializers.findContentValueSerializer(entryType, null);
 					writeMapEntries(gen, value.asMap().entrySet(), valueSerializer, serializers);
@@ -495,8 +494,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 					while (p.nextToken() != END_OBJECT) {
 						p.nextValue();
 						String key = p.currentName();
-						@SuppressWarnings("unchecked")
-						Object value = (Object) ctxt.findContextualValueDeserializer(valueType, null)
+						Object value = ctxt.findContextualValueDeserializer(valueType, null)
 							.deserialize(p, ctxt);
 						Object old = result1.put(key, value);
 						if (old != null) {

--- a/bosk-jackson/src/test/java/io/vena/bosk/jackson/JacksonPluginTest.java
+++ b/bosk-jackson/src/test/java/io/vena/bosk/jackson/JacksonPluginTest.java
@@ -106,7 +106,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 
 		// Build the expected JSON structure
 		List<Map<String, Object>> expected = new ArrayList<>();
-		entities.forEach(e1 -> expected.add(singletonMap(e1.id().toString(), plainObjectFor(e1, TypeFactory.defaultInstance().constructType(e1.getClass())))));
+		entities.forEach(e1 -> expected.add(singletonMap(e1.id().toString(), plainObjectFor(e1))));
 
 		assertJacksonWorks(expected, catalog, new TypeReference<Catalog<TestEntity>>(){}, Path.just(TestRoot.Fields.entities));
 	}
@@ -460,31 +460,31 @@ class JacksonPluginTest extends AbstractBoskTest {
 
 	private void assertJacksonWorks(Map<String,?> plainObject, Object boskObject, TypeReference<?> boskObjectTypeRef, Path path) {
 		JavaType boskObjectType = TypeFactory.defaultInstance().constructType(boskObjectTypeRef);
-		Map<String, Object> actualPlainObject = plainObjectFor(boskObject, boskObjectType);
+		Map<String, Object> actualPlainObject = plainObjectFor(boskObject);
 		assertEquals(plainObject, actualPlainObject, "Serialized object should match expected");
 
 		Object deserializedBoskObject = boskObjectFor(plainObject, boskObjectType, path);
 		assertEquals(boskObject, deserializedBoskObject, "Deserialized object should match expected");
 
-		Map<String, Object> roundTripPlainObject = plainObjectFor(deserializedBoskObject, boskObjectType);
+		Map<String, Object> roundTripPlainObject = plainObjectFor(deserializedBoskObject);
 		assertEquals(plainObject, roundTripPlainObject, "Round-trip serialized object should match expected");
 
 	}
 
 	private void assertJacksonWorks(List<?> plainList, Object boskObject, TypeReference<?> boskObjectTypeRef, Path path) {
 		JavaType boskObjectType = TypeFactory.defaultInstance().constructType(boskObjectTypeRef);
-		List<Object> actualPlainList = plainListFor(boskObject, boskObjectType);
+		List<Object> actualPlainList = plainListFor(boskObject);
 		assertEquals(plainList, actualPlainList, "Serialized object should match expected");
 
 		Object deserializedBoskObject = boskListFor(plainList, boskObjectType, path);
 		assertEquals(boskObject, deserializedBoskObject, "Deserialized object should match expected");
 
-		List<Object> roundTripPlainObject = plainListFor(deserializedBoskObject, boskObjectType);
+		List<Object> roundTripPlainObject = plainListFor(deserializedBoskObject);
 		assertEquals(plainList, roundTripPlainObject, "Round-trip serialized object should match expected");
 
 	}
 
-	private Map<String, Object> plainObjectFor(Object boskObject, JavaType boskObjectType) {
+	private Map<String, Object> plainObjectFor(Object boskObject) {
 		try {
 			JavaType mapJavaType = TypeFactory.defaultInstance().constructParametricType(Map.class, String.class, Object.class);
 			String json = boskMapper.writeValueAsString(boskObject);
@@ -494,7 +494,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 		}
 	}
 
-	private List<Object> plainListFor(Object boskObject, JavaType boskObjectType) {
+	private List<Object> plainListFor(Object boskObject) {
 		try {
 			JavaType listJavaType = TypeFactory.defaultInstance().constructParametricType(List.class, Object.class);
 			String json = boskMapper.writeValueAsString(boskObject);

--- a/bosk-jackson/src/test/java/io/vena/bosk/jackson/JacksonPluginTest.java
+++ b/bosk-jackson/src/test/java/io/vena/bosk/jackson/JacksonPluginTest.java
@@ -94,7 +94,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 
 	@ParameterizedTest
 	@MethodSource("catalogArguments")
-	void testToJson_catalog(List<String> ids) {
+	void catalog_works(List<String> ids) {
 		// Build entities and put them in a Catalog
 		List<TestEntity> entities = new ArrayList<>();
 		for (String id : ids) {
@@ -122,7 +122,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 
 	@ParameterizedTest
 	@MethodSource("listingArguments")
-	void testToJson_listing(List<String> strings, List<Identifier> ids) {
+	void listing_works(List<String> strings, List<Identifier> ids) {
 		Listing<TestEntity> listing = Listing.of(entitiesRef, ids);
 
 		Map<String, Object> expected = new LinkedHashMap<>();
@@ -144,14 +144,14 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testListingEntry() throws JsonProcessingException {
+	void listingEntry_works() throws JsonProcessingException {
 		assertEquals("true", boskMapper.writeValueAsString(LISTING_ENTRY));
 		Assertions.assertEquals(LISTING_ENTRY, boskMapper.readValue("true", ListingEntry.class));
 	}
 
 	@ParameterizedTest
 	@MethodSource("sideTableArguments")
-	void testToJson_sideTable(List<String> keys, Map<String,String> valuesByString, Map<Identifier, String> valuesById) {
+	void sideTable_works(List<String> keys, Map<String,String> valuesByString, Map<Identifier, String> valuesById) {
 		SideTable<TestEntity, String> sideTable = SideTable.fromOrderedMap(entitiesRef, valuesById);
 
 		List<Map<String, Object>> expectedList = new ArrayList<>();
@@ -193,21 +193,21 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testPhantomIsOmitted() throws InvalidTypeException, JsonProcessingException {
+	void phantom_isOmitted() throws InvalidTypeException, JsonProcessingException {
 		TestEntity entity = makeEntityWithOptionalString(Optional.empty());
 		String json = boskMapper.writeValueAsString(entity);
 		assertThat(json, not(containsString(Phantoms.Fields.phantomString)));
 	}
 
 	@Test
-	void testOptionalIsOmitted() throws InvalidTypeException, JsonProcessingException {
+	void optional_isOmitted() throws InvalidTypeException, JsonProcessingException {
 		TestEntity entity = makeEntityWithOptionalString(Optional.empty());
 		String json = boskMapper.writeValueAsString(entity);
 		assertThat(json, not(containsString(Optionals.Fields.optionalString)));
 	}
 
 	@Test
-	void testOptionalIsIncluded() throws InvalidTypeException, JsonProcessingException {
+	void optional_isIncluded() throws InvalidTypeException, JsonProcessingException {
 		String contents = "OPTIONAL STRING CONTENTS";
 		TestEntity entity = makeEntityWithOptionalString(Optional.of(contents));
 		String json = boskMapper.writeValueAsString(entity);
@@ -216,14 +216,14 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testRootReference() throws JsonProcessingException {
+	void rootReference_works() throws JsonProcessingException {
 		String json = boskMapper.writeValueAsString(bosk.rootReference());
 		assertEquals("\"/\"", json);
 	}
 
 	@ParameterizedTest
 	@MethodSource("listValueArguments")
-	void testToJson_listValue(List<?> list, JavaType type) throws JsonProcessingException {
+	void listValue_serializationWorks(List<?> list, JavaType type) throws JsonProcessingException {
 		ListValue<?> listValue = ListValue.from(list);
 		String expected = plainMapper.writeValueAsString(list);
 		assertEquals(expected, boskMapper.writerFor(type).writeValueAsString(listValue));
@@ -231,7 +231,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 
 	@ParameterizedTest
 	@MethodSource("listValueArguments")
-	void testFromJson_listValue(List<?> list, JavaType type) throws JsonProcessingException {
+	void listValue_deserializationWorks(List<?> list, JavaType type) throws JsonProcessingException {
 		ListValue<?> expected = ListValue.from(list);
 		String json = plainMapper.writeValueAsString(list);
 		Object actual = boskMapper.readerFor(type).readValue(json);
@@ -271,7 +271,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testImplicitsAreOmitted() throws InvalidTypeException, JsonProcessingException {
+	void implicitRefs_omitted() throws InvalidTypeException, JsonProcessingException {
 		TestEntity entity = makeEntityWithOptionalString(Optional.empty());
 		String json = boskMapper.writeValueAsString(entity);
 		assertThat(json, not(containsString(ImplicitRefs.Fields.reference)));
@@ -279,7 +279,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testBasicDerivedRecord() throws InvalidTypeException, JsonProcessingException {
+	void derivedRecord_basic_works() throws InvalidTypeException, JsonProcessingException {
 		Reference<ImplicitRefs> iref = parentRef.then(ImplicitRefs.class, TestEntity.Fields.implicitRefs);
 		ImplicitRefs reflectiveEntity;
 		try (ReadContext context = bosk.readContext()) {
@@ -334,7 +334,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testDerivedRecordList() throws InvalidTypeException, JsonProcessingException {
+	void derivedRecord_list_works() throws InvalidTypeException, JsonProcessingException {
 		Reference<ImplicitRefs> iref = parentRef.then(ImplicitRefs.class, TestEntity.Fields.implicitRefs);
 		ImplicitRefs reflectiveEntity;
 		try (ReadContext context = bosk.readContext()) {
@@ -364,7 +364,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testDeserializationPath() throws InvalidTypeException {
+	void deserializationPath_works() throws InvalidTypeException {
 		Reference<ImplicitRefs> anyImplicitRefs = bosk.reference(ImplicitRefs.class, Path.of(TestRoot.Fields.entities, "-entity-", TestEntity.Fields.implicitRefs));
 		Reference<ImplicitRefs> ref1 = anyImplicitRefs.boundTo(Identifier.from("123"));
 		ImplicitRefs firstObject = new ImplicitRefs(
@@ -493,7 +493,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	// Sad paths
 
 	@Test
-	void testBadJson_badReference() {
+	void nonexistentPath_throws() {
 		assertThrows(UnexpectedPathException.class, () ->
 			boskMapper
 				.readerFor(TypeFactory.defaultInstance().constructParametricType(Reference.class, String.class))
@@ -501,67 +501,67 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testBadJson_catalogFromEmptyMap() {
+	void catalogFromEmptyMap_throws() {
 		assertJsonException("{}", Catalog.class, TestEntity.class);
 	}
 
 	@Test
-	void testBadJson_catalogWithContentsArray() {
+	void catalogWithContentsArray_throws() {
 		assertJsonException("{ \"contents\": [] }", Catalog.class, TestEntity.class);
 	}
 
 	@Test
-	void testBadJson_listingWithNoCatalog() {
+	void listingWithoutDomain_throws() {
 		assertJsonException("{ \"ids\": [] }", Listing.class, TestEntity.class);
 	}
 
 	@Test
-	void testBadJson_listingWithNoIds() {
+	void listingWithoutIDs_throws() {
 		assertJsonException("{ \"domain\": \"/entities\" }", Listing.class, TestEntity.class);
 	}
 
 	@Test
-	void testBadJson_listingWithExtraneousField() {
+	void listingWithExtraneousField_throws() {
 		assertJsonException("{ \"domain\": \"/entities\", \"extraneous\": 0, \"ids\": [] }", Listing.class, TestEntity.class);
 	}
 
 	@Test
-	void testBadJson_listingWithTwoDomains() {
+	void listingWithTwoDomains_throws() {
 		assertJsonException("{ \"domain\": \"/entities\", \"domain\": \"/entities\", \"ids\": [] }", Listing.class, TestEntity.class);
 	}
 
 	@Test
-	void testBadJson_listingWithTwoIdsFields() {
+	void listingWithTwoIDsFields_throws() {
 		assertJsonException("{ \"domain\": \"/entities\", \"ids\": [], \"ids\": [] }", Listing.class, TestEntity.class);
 	}
 
 	@Test
-	void testBadJson_sideTableWithNoDomain() {
+	void sideTableWithNoDomain_throws() {
 		assertJsonException("{ \"valuesById\": [] }", SideTable.class, TestEntity.class, String.class);
 	}
 
 	@Test
-	void testBadJson_sideTableWithNoValues() {
+	void sideTableWithNoValues_throws() {
 		assertJsonException("{ \"domain\": \"/entities\" }", SideTable.class, TestEntity.class, String.class);
 	}
 
 	@Test
-	void testBadJson_sideTableWithExtraneousField() {
+	void sideTableWithExtraneousField_throws() {
 		assertJsonException("{ \"domain\": \"/entities\", \"valuesById\": [], \"extraneous\": 0 }", SideTable.class, TestEntity.class, String.class);
 	}
 
 	@Test
-	void testBadJson_sideTableWithTwoDomains() {
+	void sideTableWithTwoDomains_throws() {
 		assertJsonException("{ \"domain\": \"/entities\", \"domain\": \"/entities\", \"valuesById\": [] }", SideTable.class, TestEntity.class, String.class);
 	}
 
 	@Test
-	void testBadJson_sideTableWithValuesMap() {
+	void sideTableWithValuesMap_throws() {
 		assertJsonException("{ \"domain\": \"/entities\", \"valuesById\": {} }", SideTable.class, TestEntity.class, String.class);
 	}
 
 	@Test
-	void testBadJson_sideTableWithTwoValuesFields() {
+	void sideTableWithTwoValuesFields_throws() {
 		assertJsonException("{ \"domain\": \"/entities\", \"valuesById\": [], \"valuesById\": [] }", SideTable.class, TestEntity.class, String.class);
 	}
 
@@ -575,7 +575,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testBadDeserializationPath_wrongType() {
+	void deserializationPath_wrongType_throws() {
 		assertThrows(UnexpectedPathException.class, () -> {
 			boskMapper.readerFor(WrongType.class).readValue("{ \"notAString\": { \"id\": \"123\" } }");
 		});
@@ -588,7 +588,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testBadDeserializationPath_parameterUnbound() {
+	void deserializationPath_parameterUnbound_throws() {
 		assertThrows(ParameterUnboundException.class, () -> {
 			boskMapper.readerFor(EntityParameter.class).readValue("{ \"field\": { \"id\": \"123\" } }");
 		});
@@ -601,7 +601,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testBadDeserializationPath_malformedPath() {
+	void deserializationPath_malformedPath() {
 		assertThrows(MalformedPathException.class, () -> {
 			boskMapper.readerFor(MalformedPath.class).readValue("{ \"field\": { \"id\": \"123\" } }");
 		});
@@ -614,7 +614,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void testBadDeserializationPath_nonexistentPath() {
+	void deserializationPath_nonexistentPath_throws() {
 		assertThrows(UnexpectedPathException.class, () -> {
 			boskMapper.readerFor(NonexistentPath.class).readValue("{ \"field\": { \"id\": \"123\" } }");
 		});

--- a/bosk-jackson/src/test/java/io/vena/bosk/jackson/JacksonPluginTest.java
+++ b/bosk-jackson/src/test/java/io/vena/bosk/jackson/JacksonPluginTest.java
@@ -228,7 +228,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	void listValue_serializationWorks(List<?> list, JavaType type) throws JsonProcessingException {
 		ListValue<?> listValue = ListValue.from(list);
 		String expected = plainMapper.writeValueAsString(list);
-		assertEquals(expected, boskMapper.writerFor(type).writeValueAsString(listValue));
+		assertEquals(expected, boskMapper.writeValueAsString(listValue));
 	}
 
 	@ParameterizedTest
@@ -268,7 +268,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	void mapValue_serializationWorks(Map<String,?> map, JavaType type) throws JsonProcessingException {
 		MapValue<?> mapValue = MapValue.fromOrderedMap(map);
 		String expected = plainMapper.writeValueAsString(map);
-		assertEquals(expected, boskMapper.writerFor(type).writeValueAsString(mapValue));
+		assertEquals(expected, boskMapper.writeValueAsString(mapValue));
 	}
 
 	@ParameterizedTest
@@ -486,9 +486,8 @@ class JacksonPluginTest extends AbstractBoskTest {
 
 	private Map<String, Object> plainObjectFor(Object boskObject, JavaType boskObjectType) {
 		try {
-			JavaType boskJavaType = TypeFactory.defaultInstance().constructType(boskObjectType);
 			JavaType mapJavaType = TypeFactory.defaultInstance().constructParametricType(Map.class, String.class, Object.class);
-			String json = boskMapper.writerFor(boskJavaType).writeValueAsString(boskObject);
+			String json = boskMapper.writeValueAsString(boskObject);
 			return plainMapper.readerFor(mapJavaType).readValue(json);
 		} catch (JsonProcessingException e) {
 			throw new AssertionError(e);
@@ -497,9 +496,8 @@ class JacksonPluginTest extends AbstractBoskTest {
 
 	private List<Object> plainListFor(Object boskObject, JavaType boskObjectType) {
 		try {
-			JavaType boskJavaType = TypeFactory.defaultInstance().constructType(boskObjectType);
 			JavaType listJavaType = TypeFactory.defaultInstance().constructParametricType(List.class, Object.class);
-			String json = boskMapper.writerFor(boskJavaType).writeValueAsString(boskObject);
+			String json = boskMapper.writeValueAsString(boskObject);
 			return plainMapper.readerFor(listJavaType).readValue(json);
 		} catch (JsonProcessingException e) {
 			throw new AssertionError(e);


### PR DESCRIPTION
For generic types, we change the serialization approach so it's based on the dynamic types of the objects, rather than the static declared types of variables/fields/etc. The former is (obviously) always available, while the latter is not.

This should help the `bosk-jackson` module work much more easily with Spring Boot or other systems that already have built-in support for Jackson.

The approach for deserialization is unchanged: we still expect to have very detailed and specific static type information there for generics. As far as I know, this information is always available in a deserialization context (and, of course, the dynamic types of the objects are not). However, there is a bug fix for `gatherParameterValuesByName` that makes it resolve generic constructor argument types properly.