### PR TITLE
PathCompiler cleanup

### DIFF
--- a/bosk-core/src/main/java/io/vena/bosk/bytecode/ClassBuilder.java
+++ b/bosk-core/src/main/java/io/vena/bosk/bytecode/ClassBuilder.java
@@ -60,12 +60,13 @@ public final class ClassBuilder<T> {
 	private final List<CurriedField> curriedFields = new ArrayList<>();
 
 	/**
-	 * @param className The name of the generated class
+	 * @param className The simple name of the generated class;
+	 * 		the actual name will be given the prefix <code>GENERATED_</code> to identify it as not corresponding to any source file
 	 * @param supertype A superclass or interface for the generated class to inherit
 	 * @param parentClassLoader The classloader that should be used as the parent of the one we'll use
-	 *                          to load the newly-compiled class.
+	 * 		to load the newly-compiled class.
 	 * @param sourceFileOrigin Indicates the package in which the generated class should reside, and
-	 *                         the source file to which all debug line number information should refer.
+	 * 		the source file to which all debug line number information should refer.
 	 */
 	public ClassBuilder(String className, Class<? extends T> supertype, ClassLoader parentClassLoader, StackTraceElement sourceFileOrigin) {
 		this.supertype = supertype;
@@ -340,11 +341,17 @@ public final class ClassBuilder<T> {
 		}
 	}
 
+	/**
+	 * Bookkeeping before any instruction that causes a net increase of 1 in the operand stack depth.
+	 */
 	private void beginPush() {
 		emitLineNumberInfo();
 		currentMethod.pushSlots(1);
 	}
 
+	/**
+	 * Bookkeeping after any instruction that causes a net reduction in the operand stack depth.
+	 */
 	private void endPop(int count) {
 		currentMethod.popSlots(count);
 	}

--- a/bosk-core/src/main/java/io/vena/bosk/dereferencers/DereferencerBuilder.java
+++ b/bosk-core/src/main/java/io/vena/bosk/dereferencers/DereferencerBuilder.java
@@ -3,8 +3,24 @@ package io.vena.bosk.dereferencers;
 import io.vena.bosk.Path;
 import java.lang.reflect.Type;
 
+/**
+ * Provides info for a particular {@link Path}, determined by reflection analysis.
+ * Call {@link #buildInstance()} do perform the compilation and class loading.
+ * <p>
+ *
+ * Dereferencer construction is separated into two phases:
+ * first we create a {@link DereferencerBuilder},
+ * and then from that we compile the {@link Dereferencer}.
+ * This allows us to do just the reflection analysis, and skip the compilation and class loading,
+ * in cases where we don't need the latter.
+ */
 interface DereferencerBuilder {
 	Type targetType();
 	Path fullyParameterizedPath();
+
+	/**
+	 * Compiles and loads a new {@link Dereferencer} subclass.
+	 * @return an instance of the new {@link Dereferencer}
+	 */
 	Dereferencer buildInstance();
 }

--- a/bosk-core/src/main/java/io/vena/bosk/dereferencers/PathCompiler.java
+++ b/bosk-core/src/main/java/io/vena/bosk/dereferencers/PathCompiler.java
@@ -12,7 +12,6 @@ import io.vena.bosk.SideTable;
 import io.vena.bosk.StateTreeNode;
 import io.vena.bosk.bytecode.LocalVariable;
 import io.vena.bosk.exceptions.InvalidTypeException;
-import io.vena.bosk.exceptions.TunneledCheckedException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -89,30 +88,18 @@ public final class PathCompiler {
 	}
 
 	public Dereferencer compiled(Path path) throws InvalidTypeException {
-		try {
-			return memoizedDereferencers.computeIfAbsent(builderFor(path), DereferencerBuilder::buildInstance);
-		} catch (TunneledCheckedException e) {
-			throw e.getCause(InvalidTypeException.class);
-		}
+		return memoizedDereferencers.computeIfAbsent(builderFor(path), DereferencerBuilder::buildInstance);
 	}
 
 	public Path fullyParameterizedPathOf(Path path) throws InvalidTypeException {
-		try {
-			return builderFor(path).fullyParameterizedPath();
-		} catch (TunneledCheckedException e) {
-			throw e.getCause(InvalidTypeException.class);
-		}
+		return builderFor(path).fullyParameterizedPath();
 	}
 
 	public Type targetTypeOf(Path path) throws InvalidTypeException {
-		try {
-			return builderFor(path).targetType();
-		} catch (TunneledCheckedException e) {
-			throw e.getCause(InvalidTypeException.class);
-		}
+		return builderFor(path).targetType();
 	}
 
-	private DereferencerBuilder builderFor(Path path) throws TunneledCheckedException {
+	private DereferencerBuilder builderFor(Path path) throws InvalidTypeException {
 		// We'd like to use computeIfAbsent for this, but we can't,
 		// because in some cases we need to add two entries to the map
 		// (for the given path and the fully parameterized one)
@@ -134,10 +121,10 @@ public final class PathCompiler {
 	 * Note: also memoizes the resulting builder under the fully parameterized path
 	 * if different from the given path.
 	 */
-	private DereferencerBuilder getOrCreateBuilder(Path path) throws TunneledCheckedException {
+	private DereferencerBuilder getOrCreateBuilder(Path path) throws InvalidTypeException {
 		if (path.isEmpty()) {
 			return ROOT_BUILDER;
-		} else try {
+		} else {
 			StepwiseDereferencerBuilder candidate = new StepwiseDereferencerBuilder(path, here());
 
 			// If there's already an equivalent one filed under
@@ -150,8 +137,6 @@ public final class PathCompiler {
 				keepAliveFullyParameterizedPaths.add(fullyParameterizedPath);
 			}
 			return result;
-		} catch (InvalidTypeException e) {
-			throw new TunneledCheckedException(e);
 		}
 	}
 

--- a/bosk-core/src/main/java/io/vena/bosk/dereferencers/SkeletonDereferencerBuilder.java
+++ b/bosk-core/src/main/java/io/vena/bosk/dereferencers/SkeletonDereferencerBuilder.java
@@ -7,8 +7,13 @@ import java.lang.reflect.Method;
 /**
  * The skeleton of a builder for {@link Dereferencer} objects. Creates a new class,
  * declares its methods, and calls a sequence of abstract methods to generate the
- * method bodies. Provides protected utility methods that can be called to generate
+ * method bodies.
+ * Provides protected utility methods that can be called to generate
  * the desired bytecodes for the method bodies.
+ * The intent is that subclasses won't need to call {@link ClassBuilder} directly,
+ * but can instead call the slightly simpler set of methods provided here.
+ * (The only exception is {@link ClassBuilder#here}, which must be called directly
+ * in order to return the correct stack information.)
  *
  * <p>
  * By "skeleton" here we really mean the GoF "Template Method" pattern inside
@@ -48,7 +53,7 @@ abstract class SkeletonDereferencerBuilder implements DereferencerBuilder {
 	 * Pushes the bosk root object onto the operand stack, and typecasts it to the given class.
 	 */
 	protected final void pushSourceObject(Class<?> expectedType) {
-		cb.pushLocal(cb.parameter(1));
+		cb.pushLocal(cb.parameter(1)); // Parameter 0 is the Dereferencer object itself
 		cb.castTo(expectedType);
 	}
 


### PR DESCRIPTION
Lots of javadocs, a little refactoring, and a fix to help support method parameters and return types `double` and `long` (not yet tested).