### PR TITLE
Inline deprecated Bosk reference methods

### DIFF
--- a/bosk-core/src/main/java/io/vena/bosk/Bosk.java
+++ b/bosk-core/src/main/java/io/vena/bosk/Bosk.java
@@ -832,22 +832,22 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 
 		@Override
 		public final <U extends Entity> CatalogReference<U> thenCatalog(Class<U> entryClass, String... segments) throws InvalidTypeException {
-			return catalogReference(entryClass, path.then(segments));
+			return rootReference().thenCatalog(entryClass, path.then(segments));
 		}
 
 		@Override
 		public final <U extends Entity> ListingReference<U> thenListing(Class<U> entryClass, String... segments) throws InvalidTypeException {
-			return listingReference(entryClass, path.then(segments));
+			return rootReference().thenListing(entryClass, path.then(segments));
 		}
 
 		@Override
 		public final <K extends Entity, V> SideTableReference<K, V> thenSideTable(Class<K> keyClass, Class<V> valueClass, String... segments) throws InvalidTypeException {
-			return sideTableReference(keyClass, valueClass, path.then(segments));
+			return rootReference().thenSideTable(keyClass, valueClass, path.then(segments));
 		}
 
 		@Override
 		public final <TT> Reference<Reference<TT>> thenReference(Class<TT> targetClass, String... segments) throws InvalidTypeException {
-			return referenceReference(targetClass, path.then(segments));
+			return rootReference().thenReference(targetClass, path.then(segments));
 		}
 
 		@SuppressWarnings("unchecked")

--- a/bosk-core/src/main/java/io/vena/bosk/Bosk.java
+++ b/bosk-core/src/main/java/io/vena/bosk/Bosk.java
@@ -548,7 +548,7 @@ public class Bosk<R extends StateTreeNode> {
 				// could correspond to changed objects and then recursing.
 				//
 				Path containerPath = effectiveScope.path().truncatedTo(effectiveScope.path().firstParameterIndex());
-				Reference<EnumerableByIdentifier<?>> containerRef = reference(enumerableByIdentifierClass(), containerPath);
+				Reference<EnumerableByIdentifier<?>> containerRef = rootReference().then(enumerableByIdentifierClass(), containerPath);
 				EnumerableByIdentifier<?> priorContainer = refValueIfExists(containerRef, priorRoot);
 				EnumerableByIdentifier<?> newContainer = refValueIfExists(containerRef, newRoot);
 
@@ -777,25 +777,25 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 
 		@Override
 		public <E extends Entity> CatalogReference<E> thenCatalog(Class<E> entryClass, Path path) throws InvalidTypeException {
-			Reference<Catalog<E>> ref = reference(Classes.catalog(entryClass), path);
+			Reference<Catalog<E>> ref = this.then(Classes.catalog(entryClass), path);
 			return new CatalogRef<>(ref, entryClass);
 		}
 
 		@Override
 		public <E extends Entity> ListingReference<E> thenListing(Class<E> entryClass, Path path) throws InvalidTypeException {
-			Reference<Listing<E>> ref = reference(Classes.listing(entryClass), path);
+			Reference<Listing<E>> ref = this.then(Classes.listing(entryClass), path);
 			return new ListingRef<>(ref);
 		}
 
 		@Override
 		public <K extends Entity, V> SideTableReference<K, V> thenSideTable(Class<K> keyClass, Class<V> valueClass, Path path) throws InvalidTypeException {
-			Reference<SideTable<K,V>> ref = reference(Classes.sideTable(keyClass, valueClass), path);
+			Reference<SideTable<K,V>> ref = this.then(Classes.sideTable(keyClass, valueClass), path);
 			return new SideTableRef<>(ref, keyClass, valueClass);
 		}
 
 		@Override
 		public <TT> Reference<Reference<TT>> thenReference(Class<TT> targetClass, Path path) throws InvalidTypeException {
-			return reference(Classes.reference(targetClass), path);
+			return this.then(Classes.reference(targetClass), path);
 		}
 
 		@Override
@@ -827,7 +827,7 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 
 		@Override
 		public final <U> Reference<U> then(Class<U> targetClass, String... segments) throws InvalidTypeException {
-			return reference(targetClass, path.then(segments));
+			return rootReference().then(targetClass, path.then(segments));
 		}
 
 		@Override
@@ -859,13 +859,13 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 			for (Path p = this.path.truncatedBy(1); !p.isEmpty(); p = p.truncatedBy(1)) try {
 				Type targetType = pathCompiler.targetTypeOf(p);
 				if (targetClass.isAssignableFrom(rawClass(targetType))) {
-					return reference(targetClass, p);
+					return rootReference().then(targetClass, p);
 				}
 			} catch (InvalidTypeException e) {
 				throw new InvalidTypeException("Error looking up enclosing " + targetClass.getSimpleName() + " from " + path);
 			}
 			// Might be the root
-			if (targetClass.isAssignableFrom(rawClass(rootRef.targetType()))) {
+			if (targetClass.isAssignableFrom(rootRef.targetClass())) {
 				return (Reference<TT>) rootReference();
 			} else {
 				throw new InvalidTypeException("No enclosing " + targetClass.getSimpleName() + " from " + path);
@@ -901,7 +901,7 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 		}
 
 		private Type rootType() {
-			return Bosk.this.rootRef.targetType();
+			return Bosk.this.rootRef.targetType;
 		}
 
 		@Override
@@ -976,7 +976,7 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 			Path containerPath = path.truncatedTo(firstParameterIndex);
 			Reference<EnumerableByIdentifier<?>> containerRef;
 			try {
-				containerRef = reference(enumerableByIdentifierClass(), containerPath);
+				containerRef = rootReference().then(enumerableByIdentifierClass(), containerPath);
 			} catch (InvalidTypeException e) {
 				throw new AssertionError("Parameter reference must come after a " + EnumerableByIdentifier.class, e);
 			}

--- a/bosk-core/src/main/java/io/vena/bosk/ReferenceBuilder.java
+++ b/bosk-core/src/main/java/io/vena/bosk/ReferenceBuilder.java
@@ -41,14 +41,14 @@ class ReferenceBuilder {
 				Path path = Path.parseParameterized(referencePath.value());
 				if (returnClass.equals(CatalogReference.class)) {
 					Type entryType = parameterType(returnType, CatalogReference.class, 0);
-					result = bosk.catalogReference((Class) rawClass(entryType), path);
+					result = bosk.rootReference().thenCatalog((Class) rawClass(entryType), path);
 				} else if (returnClass.equals(ListingReference.class)) {
 					Type entryType = parameterType(returnType, ListingReference.class, 0);
-					result = bosk.listingReference((Class) rawClass(entryType), path);
+					result = bosk.rootReference().thenListing((Class) rawClass(entryType), path);
 				} else if (returnClass.equals(SideTableReference.class)) {
 					Type keyType = parameterType(returnType, SideTableReference.class, 0);
 					Type valueType = parameterType(returnType, SideTableReference.class, 1);
-					result = bosk.sideTableReference((Class) rawClass(keyType), (Class) rawClass(valueType), path);
+					result = bosk.rootReference().thenSideTable((Class) rawClass(keyType), (Class) rawClass(valueType), path);
 				} else {
 					result = bosk.rootReference().then(rawClass(targetType), path);
 				}

--- a/bosk-core/src/main/java/io/vena/bosk/ReferenceBuilder.java
+++ b/bosk-core/src/main/java/io/vena/bosk/ReferenceBuilder.java
@@ -50,7 +50,7 @@ class ReferenceBuilder {
 					Type valueType = parameterType(returnType, SideTableReference.class, 1);
 					result = bosk.sideTableReference((Class) rawClass(keyType), (Class) rawClass(valueType), path);
 				} else {
-					result = bosk.reference(rawClass(targetType), path);
+					result = bosk.rootReference().then(rawClass(targetType), path);
 				}
 			} catch (InvalidTypeException e) {
 				// Add some troubleshooting info for the user

--- a/bosk-core/src/main/java/io/vena/bosk/SerializationPlugin.java
+++ b/bosk-core/src/main/java/io/vena/bosk/SerializationPlugin.java
@@ -223,7 +223,7 @@ public abstract class SerializationPlugin {
 	private <T> Reference<T> selfReference(Class<T> targetClass, Bosk<?> bosk) throws AssertionError {
 		Path currentPath = currentScope.get().path();
 		try {
-			return bosk.reference(targetClass, currentPath);
+			return bosk.rootReference().then(targetClass, currentPath);
 		} catch (InvalidTypeException e) {
 			throw new UnexpectedPathException("currentDeserializationPath should be valid: \"" + currentPath + "\"", e);
 		}

--- a/bosk-core/src/main/java/io/vena/bosk/drivers/MirroringDriver.java
+++ b/bosk-core/src/main/java/io/vena/bosk/drivers/MirroringDriver.java
@@ -66,7 +66,7 @@ public class MirroringDriver<R extends Entity> implements BoskDriver<R> {
 	@SuppressWarnings("unchecked")
 	private <T> Reference<T> correspondingReference(Reference<T> original) {
 		try {
-			return (Reference<T>)mirror.reference(Object.class, original.path());
+			return (Reference<T>) mirror.rootReference().then(Object.class, original.path());
 		} catch (InvalidTypeException e) {
 			throw new AssertionError("References are expected to be compatible: " + original, e);
 		}

--- a/bosk-core/src/test/java/io/vena/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/BoskLocalReferenceTest.java
@@ -122,7 +122,7 @@ class BoskLocalReferenceTest {
 		Path entitiesPath = Path.just(Root.Fields.entities);
 		List<Reference<Catalog<TestEntity>>> testRefs = asList(
 			bosk.rootReference().then(catalogClass, entitiesPath),
-			bosk.catalogReference(TestEntity.class, entitiesPath),
+			bosk.rootReference().thenCatalog(TestEntity.class, entitiesPath),
 			bosk.rootReference().thenCatalog(TestEntity.class, Root.Fields.entities),
 			refs.entities());
 		for (Reference<Catalog<TestEntity>> catalogRef: testRefs) {
@@ -144,7 +144,7 @@ class BoskLocalReferenceTest {
 		for (Identifier id: root.entities.ids()) {
 			Path listingPath = Path.of(Root.Fields.entities, id.toString(), TestEntity.Fields.listing);
 			List<ListingReference<TestEntity>> testRefs = asList(
-					bosk.listingReference(TestEntity.class, listingPath),
+					bosk.rootReference().thenListing(TestEntity.class, listingPath),
 					bosk.rootReference().thenListing(TestEntity.class, Root.Fields.entities, id.toString(), TestEntity.Fields.listing),
 					bosk.rootReference().thenListing(TestEntity.class, Root.Fields.entities, "-entity-", TestEntity.Fields.listing).boundTo(id)
 					);
@@ -192,7 +192,7 @@ class BoskLocalReferenceTest {
 		for (Identifier id: root.entities.ids()) {
 			Path sideTablePath = Path.of(Root.Fields.entities, id.toString(), TestEntity.Fields.sideTable);
 			List<SideTableReference<TestEntity,String>> testRefs = asList(
-					bosk.sideTableReference(TestEntity.class, String.class, sideTablePath),
+					bosk.rootReference().thenSideTable(TestEntity.class, String.class, sideTablePath),
 					bosk.rootReference().thenSideTable(TestEntity.class, String.class, Root.Fields.entities, id.toString(), TestEntity.Fields.sideTable),
 					bosk.rootReference().thenSideTable(TestEntity.class, String.class, Root.Fields.entities, "-entity-", TestEntity.Fields.sideTable).boundTo(id)
 					);
@@ -226,7 +226,7 @@ class BoskLocalReferenceTest {
 		for (Identifier id: root.entities.ids()) {
 			Path refPath = Path.of(Root.Fields.entities, id.toString(), TestEntity.Fields.refField);
 			List<Reference<Reference<TestEntity>>> testRefs = asList(
-					bosk.referenceReference(TestEntity.class, refPath),
+					bosk.rootReference().thenReference(TestEntity.class, refPath),
 					bosk.rootReference().thenReference(TestEntity.class, Root.Fields.entities, id.toString(), TestEntity.Fields.refField),
 					bosk.rootReference().thenReference(TestEntity.class, Root.Fields.entities, "-entity-", TestEntity.Fields.refField).boundTo(id)
 			);

--- a/bosk-core/src/test/java/io/vena/bosk/HooksTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/HooksTest.java
@@ -43,7 +43,7 @@ public class HooksTest extends AbstractBoskTest {
 	@BeforeEach
 	void setupBosk() throws InvalidTypeException {
 		bosk = setUpBosk(Bosk::simpleDriver);
-		refs = bosk.buildReferences(Refs.class);
+		refs = bosk.rootReference().buildReferences(Refs.class);
 		try (val __ = bosk.readContext()) {
 			originalRoot = bosk.rootReference().value();
 			originalParent = refs.parent().value();

--- a/bosk-core/src/test/java/io/vena/bosk/ListingTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/ListingTest.java
@@ -57,7 +57,7 @@ class ListingTest {
 						Bosk<TestEntity> bosk = new Bosk<>("Test Bosk", TestEntity.class, root, Bosk::simpleDriver);
 						CatalogReference<TestEntity> catalog;
 						try {
-							catalog = bosk.catalogReference(TestEntity.class, Path.just(TestEntity.Fields.children));
+							catalog = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 						} catch (InvalidTypeException e) {
 							throw new AssertionError(e);
 						}
@@ -74,7 +74,7 @@ class ListingTest {
 			List<TestEntity> children = singletonList(child);
 			TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
 			Bosk<TestEntity> bosk = new Bosk<>("Test Bosk", TestEntity.class, root, Bosk::simpleDriver);
-			CatalogReference<TestEntity> childrenRef = bosk.catalogReference(TestEntity.class, Path.just(TestEntity.Fields.children));
+			CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 			return idStreams().map(list -> Arguments.of(list.map(Identifier::from).collect(toList()), childrenRef, bosk));
 		}
 
@@ -249,7 +249,7 @@ class ListingTest {
 		List<TestEntity> children = singletonList(child);
 		TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
 		Bosk<TestEntity> bosk = new Bosk<>("Test Bosk", TestEntity.class, root, Bosk::simpleDriver);
-		CatalogReference<TestEntity> childrenRef = bosk.catalogReference(TestEntity.class, Path.just(TestEntity.Fields.children));
+		CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 
 		Listing<TestEntity> actual = Listing.empty(childrenRef);
 		assertTrue(actual.isEmpty());
@@ -382,7 +382,7 @@ class ListingTest {
 	@ParameterizedTest
 	@ArgumentsSource(ListingArgumentProvider.class)
 	void testScope(Listing<TestEntity> listing, List<TestEntity> children, Bosk<TestEntity> bosk) throws InvalidTypeException {
-		Reference<Catalog<TestEntity>> expected = bosk.catalogReference(TestEntity.class, Path.just(TestEntity.Fields.children));
+		Reference<Catalog<TestEntity>> expected = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 		assertEquals(expected, listing.domain());
 	}
 

--- a/bosk-core/src/test/java/io/vena/bosk/ListingTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/ListingTest.java
@@ -38,6 +38,10 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/*
+ * TODO: This test is written in a mighty weird style. Change it to set up
+ * the bosk in a more normal manner, and try to use buildReferences too.
+ */
 class ListingTest {
 
 	static class ListingArgumentProvider implements ArgumentsProvider {

--- a/bosk-core/src/test/java/io/vena/bosk/OptionalRefsTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/OptionalRefsTest.java
@@ -23,7 +23,7 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 	@Test
 	void testReferenceOptionalNotAllowed() {
 		Bosk<OptionalString> bosk = new Bosk<>("optionalNotAllowed", OptionalString.class, new OptionalString(ID, Optional.empty()), Bosk::simpleDriver);
-		InvalidTypeException e = assertThrows(InvalidTypeException.class, () -> bosk.reference(Optional.class, Path.just("field")));
+		InvalidTypeException e = assertThrows(InvalidTypeException.class, () -> bosk.rootReference().then(Optional.class, Path.just("field")));
 		assertThat(e.getMessage(), containsString("not supported"));
 	}
 
@@ -134,7 +134,7 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 
 		// Try other ways of getting the same reference
 		@SuppressWarnings("unchecked")
-		Reference<V> ref2 = bosk.reference((Class<V>)value.getClass(), Path.just("field"));
+		Reference<V> ref2 = bosk.rootReference().then((Class<V>) value.getClass(), Path.just("field"));
 		assertEquals(optionalRef, ref2);
 	}
 

--- a/bosk-core/src/test/java/io/vena/bosk/ReferenceBenchmark.java
+++ b/bosk-core/src/test/java/io/vena/bosk/ReferenceBenchmark.java
@@ -41,7 +41,7 @@ public class ReferenceBenchmark extends AbstractBoskTest {
 			rootRef = bosk.rootReference();
 			TestRoot localRoot = root = rootRef.value();
 			threadLocalRoot = ThreadLocal.withInitial(() -> localRoot);
-			ref5Segments = bosk.reference(TestEnum.class, Path.of(
+			ref5Segments = bosk.rootReference().then(TestEnum.class, Path.of(
 				TestRoot.Fields.entities, "parent",
 				TestEntity.Fields.children, "child1",
 				TestChild.Fields.testEnum

--- a/bosk-core/src/test/java/io/vena/bosk/ReferenceErrorTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/ReferenceErrorTest.java
@@ -25,7 +25,7 @@ public class ReferenceErrorTest {
 
 	@Test
 	void referenceGet_brokenGetter_propagatesException() throws InvalidTypeException {
-		Reference<Identifier> idRef = bosk.reference(Identifier.class, Path.just("id"));
+		Reference<Identifier> idRef = bosk.rootReference().then(Identifier.class, Path.just("id"));
 		try (val __ = bosk.readContext()) {
 			assertThrows(UnsupportedOperationException.class, idRef::value,
 				"Reference.value() should propagate the exception as-is");
@@ -34,7 +34,7 @@ public class ReferenceErrorTest {
 
 	@Test
 	void referenceUpdate_brokenGetter_propagatesException() throws InvalidTypeException {
-		Reference<String> stringRef = bosk.reference(String.class, Path.of(BadGetters.Fields.nestedObject, NestedObject.Fields.string));
+		Reference<String> stringRef = bosk.rootReference().then(String.class, Path.of(BadGetters.Fields.nestedObject, NestedObject.Fields.string));
 		assertThrows(UnsupportedOperationException.class, ()->
 			bosk.driver().submitReplacement(stringRef, "newValue"));
 		assertThrows(UnsupportedOperationException.class, ()->

--- a/bosk-core/src/test/java/io/vena/bosk/ReferenceTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/ReferenceTest.java
@@ -46,7 +46,7 @@ class ReferenceTest extends AbstractBoskTest {
 
 	@Test
 	void rootFields_referenceValue_returnsCorrectObject() throws InvalidTypeException {
-		assertSame(root.entities(), bosk.catalogReference(TestEntity.class, Path.just(
+		assertSame(root.entities(), bosk.rootReference().thenCatalog(TestEntity.class, Path.just(
 			TestRoot.Fields.entities
 		)).value());
 		assertSame(root.someStrings(), bosk.rootReference().then(StringListValueSubclass.class, Path.just(

--- a/bosk-core/src/test/java/io/vena/bosk/ReferenceTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/ReferenceTest.java
@@ -38,7 +38,7 @@ class ReferenceTest extends AbstractBoskTest {
 
 	@Test
 	void root_matches() throws InvalidTypeException {
-		Reference<TestEntity> parentRef = bosk.reference(TestEntity.class, Path.of(
+		Reference<TestEntity> parentRef = bosk.rootReference().then(TestEntity.class, Path.of(
 			TestRoot.Fields.entities, "parent"
 		));
 		assertEquals(bosk.rootReference(), parentRef.root());
@@ -49,17 +49,17 @@ class ReferenceTest extends AbstractBoskTest {
 		assertSame(root.entities(), bosk.catalogReference(TestEntity.class, Path.just(
 			TestRoot.Fields.entities
 		)).value());
-		assertSame(root.someStrings(), bosk.reference(StringListValueSubclass.class, Path.just(
+		assertSame(root.someStrings(), bosk.rootReference().then(StringListValueSubclass.class, Path.just(
 			TestRoot.Fields.someStrings
 		)).value());
-		assertSame(root.someMappedStrings(), bosk.reference(mapValue(String.class), Path.just(
+		assertSame(root.someMappedStrings(), bosk.rootReference().then(mapValue(String.class), Path.just(
 			TestRoot.Fields.someMappedStrings
 		)).value());
 	}
 
 	@Test
 	void parentFields_referenceValue_returnsCorrectObject() throws InvalidTypeException {
-		Reference<TestEntity> parentRef = bosk.reference(TestEntity.class, Path.of(
+		Reference<TestEntity> parentRef = bosk.rootReference().then(TestEntity.class, Path.of(
 			TestRoot.Fields.entities, "parent"
 		));
 		TestEntity parent = root.entities().get(Identifier.from("parent"));
@@ -77,7 +77,7 @@ class ReferenceTest extends AbstractBoskTest {
 
 	@Test
 	void phantomFields_reference_nonexistent() throws InvalidTypeException {
-		Reference<Phantoms> phantomsRef = bosk.reference(Phantoms.class, Path.of(
+		Reference<Phantoms> phantomsRef = bosk.rootReference().then(Phantoms.class, Path.of(
 			TestRoot.Fields.entities, "parent", TestEntity.Fields.phantoms
 		));
 		Phantoms phantoms = root.entities().get(Identifier.from("parent")).phantoms();
@@ -93,7 +93,7 @@ class ReferenceTest extends AbstractBoskTest {
 
 	@Test
 	void optionalFields_referenceValueIfExists_returnsCorrectResult() throws InvalidTypeException {
-		Reference<Optionals> optionalsRef = bosk.reference(Optionals.class, Path.of(
+		Reference<Optionals> optionalsRef = bosk.rootReference().then(Optionals.class, Path.of(
 			TestRoot.Fields.entities, "parent", TestEntity.Fields.optionals
 		));
 		Optionals optionals = root.entities().get(Identifier.from("parent")).optionals();
@@ -110,7 +110,7 @@ class ReferenceTest extends AbstractBoskTest {
 	@Test
 	void forEach_definiteReference_noMatches() throws InvalidTypeException {
 		assertForEachValueWorks(
-			bosk.reference(TestEntity.class, Path.of(
+			bosk.rootReference().then(TestEntity.class, Path.of(
 				TestRoot.Fields.entities, "nonexistent")),
 			emptyList(),
 			emptyList()
@@ -120,7 +120,7 @@ class ReferenceTest extends AbstractBoskTest {
 	@Test
 	void forEach_definiteReference_oneMatch() throws InvalidTypeException {
 		assertForEachValueWorks(
-			bosk.reference(TestEntity.class, Path.of(
+			bosk.rootReference().then(TestEntity.class, Path.of(
 				TestRoot.Fields.entities, "parent")),
 			singletonList(root.entities().get(Identifier.from("parent"))),
 			singletonList(BindingEnvironment.empty())
@@ -130,7 +130,7 @@ class ReferenceTest extends AbstractBoskTest {
 	@Test
 	void forEach_indefiniteReference_noMatches() throws InvalidTypeException {
 		assertForEachValueWorks(
-			bosk.reference(String.class, Path.of(
+			bosk.rootReference().then(String.class, Path.of(
 				TestRoot.Fields.entities, "nonexistent", TestEntity.Fields.stringSideTable, "-child-")),
 			emptyList(),
 			emptyList()
@@ -140,7 +140,7 @@ class ReferenceTest extends AbstractBoskTest {
 	@Test
 	void forEach_indefiniteReference_oneMatch() throws InvalidTypeException {
 		assertForEachValueWorks(
-			bosk.reference(String.class, Path.of(
+			bosk.rootReference().then(String.class, Path.of(
 				TestRoot.Fields.entities, "parent", TestEntity.Fields.stringSideTable, "-child-")),
 			singletonList(root.entities().get(Identifier.from("parent")).stringSideTable().get(Identifier.from("child2"))),
 			singletonList(BindingEnvironment.singleton("child", Identifier.from("child2")))
@@ -151,7 +151,7 @@ class ReferenceTest extends AbstractBoskTest {
 	void forEach_indefiniteReference_multipleMatches() throws InvalidTypeException {
 		Catalog<TestChild> children = root.entities().get(Identifier.from("parent")).children();
 		assertForEachValueWorks(
-			bosk.reference(TestChild.class, Path.of(
+			bosk.rootReference().then(TestChild.class, Path.of(
 				TestRoot.Fields.entities, "parent", TestEntity.Fields.children, "-child-")),
 			children.stream().collect(toList()),
 			children.idStream().map(id -> BindingEnvironment.singleton("child", id)).collect(toList())

--- a/bosk-core/src/test/java/io/vena/bosk/dereferencers/PathCompilerTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/dereferencers/PathCompilerTest.java
@@ -273,7 +273,7 @@ public class PathCompilerTest extends AbstractBoskTest {
 			initialRoot,
 			Bosk::simpleDriver
 		);
-		Reference<Identifier> idRef = differentBosk.reference(Identifier.class, Path.parse(
+		Reference<Identifier> idRef = differentBosk.rootReference().then(Identifier.class, Path.parse(
 			"/id" ));
 
 		try (Bosk<?>.ReadContext context = differentBosk.readContext()) {
@@ -387,7 +387,7 @@ public class PathCompilerTest extends AbstractBoskTest {
 			// Because this is a test of PathCompiler, we want this to look like
 			// a test failure, not an initialization error, especially because
 			// pitest doesn't count initialization errors as "killed mutations".
-			ref = bosk.reference(Object.class, path);
+			ref = bosk.rootReference().then(Object.class, path);
 			actual = pathCompiler.compiled(path);
 		} catch (Exception | AssertionError e) {
 			return singletonList(DynamicTest.dynamicTest(description + ": PathCompiler should not throw", () -> { throw new AssertionError("PathCompiler exception", e); }));

--- a/bosk-gson/src/main/java/io/vena/bosk/gson/GsonPlugin.java
+++ b/bosk-gson/src/main/java/io/vena/bosk/gson/GsonPlugin.java
@@ -171,7 +171,7 @@ public final class GsonPlugin extends SerializationPlugin {
 			@Override
 			public Reference<?> read(JsonReader in) throws IOException {
 				try {
-					return bosk.reference(Object.class, Path.parse(in.nextString()));
+					return bosk.rootReference().then(Object.class, Path.parse(in.nextString()));
 				} catch (InvalidTypeException e) {
 					throw new UnexpectedPathException(e);
 				}

--- a/bosk-gson/src/test/java/io/vena/bosk/gson/GsonPluginTest.java
+++ b/bosk-gson/src/test/java/io/vena/bosk/gson/GsonPluginTest.java
@@ -374,7 +374,7 @@ class GsonPluginTest extends AbstractBoskTest {
 
 	@Test
 	void testDeserializationPath() throws InvalidTypeException {
-		Reference<ImplicitRefs> anyImplicitRefs = bosk.reference(ImplicitRefs.class, Path.of(TestRoot.Fields.entities, "-entity-", TestEntity.Fields.implicitRefs));
+		Reference<ImplicitRefs> anyImplicitRefs = bosk.rootReference().then(ImplicitRefs.class, Path.of(TestRoot.Fields.entities, "-entity-", TestEntity.Fields.implicitRefs));
 		Reference<ImplicitRefs> ref1 = anyImplicitRefs.boundTo(Identifier.from("123"));
 		ImplicitRefs firstObject = new ImplicitRefs(
 			Identifier.from("firstObject"),

--- a/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
@@ -350,7 +350,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 				@Override
 				public Reference<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
 					try {
-						return bosk.reference(Object.class, Path.parse(p.getText()));
+						return bosk.rootReference().then(Object.class, Path.parse(p.getText()));
 					} catch (InvalidTypeException e) {
 						throw new UnexpectedPathException(e);
 					}

--- a/bosk-jackson/src/test/java/io/vena/bosk/jackson/JacksonPluginTest.java
+++ b/bosk-jackson/src/test/java/io/vena/bosk/jackson/JacksonPluginTest.java
@@ -428,7 +428,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 
 	@Test
 	void deserializationPath_works() throws InvalidTypeException {
-		Reference<ImplicitRefs> anyImplicitRefs = bosk.reference(ImplicitRefs.class, Path.of(TestRoot.Fields.entities, "-entity-", TestEntity.Fields.implicitRefs));
+		Reference<ImplicitRefs> anyImplicitRefs = bosk.rootReference().then(ImplicitRefs.class, Path.of(TestRoot.Fields.entities, "-entity-", TestEntity.Fields.implicitRefs));
 		Reference<ImplicitRefs> ref1 = anyImplicitRefs.boundTo(Identifier.from("123"));
 		ImplicitRefs firstObject = new ImplicitRefs(
 			Identifier.from("firstObject"),

--- a/bosk-jackson/src/test/java/io/vena/bosk/jackson/JacksonPluginTest.java
+++ b/bosk-jackson/src/test/java/io/vena/bosk/jackson/JacksonPluginTest.java
@@ -82,7 +82,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	void setUpJackson() throws Exception {
 		bosk = setUpBosk(Bosk::simpleDriver);
 		teb = new TestEntityBuilder(bosk);
-		entitiesRef = bosk.catalogReference(TestEntity.class, Path.just(TestRoot.Fields.entities));
+		entitiesRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestRoot.Fields.entities));
 		parentRef = entitiesRef.then(Identifier.from("parent"));
 
 		plainMapper = new ObjectMapper()

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/BsonPlugin.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/BsonPlugin.java
@@ -392,7 +392,7 @@ public final class BsonPlugin extends SerializationPlugin {
 			public Reference<?> decode(BsonReader reader, DecoderContext decoderContext) {
 				String urlEncoded = reader.readString();
 				try {
-					return bosk.reference(Object.class, Path.parse(urlEncoded));
+					return bosk.rootReference().then(Object.class, Path.parse(urlEncoded));
 				} catch (InvalidTypeException e) {
 					throw new UnexpectedPathException(e);
 				}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SingleDocumentMongoChangeStreamReceiver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SingleDocumentMongoChangeStreamReceiver.java
@@ -345,7 +345,7 @@ final class SingleDocumentMongoChangeStreamReceiver<R extends StateTreeNode> imp
 				// getFullDocument is reliable for INSERT and REPLACE operations:
 				//   https://docs.mongodb.com/v4.0/reference/change-events/#change-stream-output
 				LOGGER.debug("| Replace document - IGNORE");
-				//driver.submitReplacement(rootReference, document2object(event.getFullDocument().get(DocumentFields.root), rootReference));
+				//driver.submitReplacement(rootRef, document2object(event.getFullDocument().get(DocumentFields.root), rootRef));
 				// TODO
 				break;
 			case UPDATE:

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/BsonPluginTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/BsonPluginTest.java
@@ -44,7 +44,7 @@ class BsonPluginTest {
 	}
 
 	private Root defaultRoot(Bosk<Root> bosk) throws InvalidTypeException {
-		CatalogReference<Item> catalogRef = bosk.catalogReference(Item.class, Path.just(Root.Fields.items));
+		CatalogReference<Item> catalogRef = bosk.rootReference().thenCatalog(Item.class, Path.just(Root.Fields.items));
 		return new Root(Catalog.empty(), SideTable.empty(catalogRef));
 	}
 

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverDottedFieldNameTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverDottedFieldNameTest.java
@@ -31,7 +31,7 @@ class MongoDriverDottedFieldNameTest extends AbstractDriverTest {
 	}
 
 	private CatalogReference<TestEntity> rootCatalogRef(Bosk<TestEntity> bosk) throws InvalidTypeException {
-		return bosk.catalogReference(TestEntity.class, Path.just( TestEntity.Fields.catalog));
+		return bosk.rootReference().thenCatalog(TestEntity.class, Path.just( TestEntity.Fields.catalog));
 	}
 
 	static class PathArgumentProvider implements ArgumentsProvider {

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverDottedFieldNameTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverDottedFieldNameTest.java
@@ -60,7 +60,7 @@ class MongoDriverDottedFieldNameTest extends AbstractDriverTest {
 	@ParameterizedTest
 	@ArgumentsSource(PathArgumentProvider.class)
 	void testDottedFieldNameOf(String boskPath, String dottedFieldName) throws InvalidTypeException {
-		Reference<?> reference = bosk.reference(Object.class, Path.parse(boskPath));
+		Reference<?> reference = bosk.rootReference().then(Object.class, Path.parse(boskPath));
 		String actual = Formatter.dottedFieldNameOf(reference, bosk.rootReference());
 		assertEquals(dottedFieldName, actual);
 		//assertThrows(AssertionError.class, ()-> MongoDriver.dottedFieldNameOf(reference, catalogReference.then(Identifier.from("whoopsie"))));
@@ -69,7 +69,7 @@ class MongoDriverDottedFieldNameTest extends AbstractDriverTest {
 	@ParameterizedTest
 	@ArgumentsSource(PathArgumentProvider.class)
 	void testReferenceTo(String boskPath, String dottedFieldName) throws InvalidTypeException {
-		Reference<?> expected = bosk.reference(Object.class, Path.parse(boskPath));
+		Reference<?> expected = bosk.rootReference().then(Object.class, Path.parse(boskPath));
 		Reference<?> actual = Formatter.referenceTo(dottedFieldName, bosk.rootReference());
 		assertEquals(expected, actual);
 		assertEquals(expected.path(), actual.path());

--- a/bosk-spring-boot-3/src/main/java/io/vena/bosk/spring/boot/ServiceEndpoints.java
+++ b/bosk-spring-boot-3/src/main/java/io/vena/bosk/spring/boot/ServiceEndpoints.java
@@ -120,7 +120,7 @@ public class ServiceEndpoints {
 			boskPath = "/";
 		}
 		try {
-			return bosk.reference(Object.class, Path.parse(boskPath));
+			return bosk.rootReference().then(Object.class, Path.parse(boskPath));
 		} catch (InvalidTypeException e) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Invalid path: " + path, e);
 		}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/AbstractDriverTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractDriverTest {
 	}
 
 	private static TestEntity initialRoot(Bosk<TestEntity> b) throws InvalidTypeException {
-		return TestEntity.empty(Identifier.from("root"), b.catalogReference(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+		return TestEntity.empty(Identifier.from("root"), b.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
 	}
 
 	TestEntity autoInitialize(Reference<TestEntity> ref) {

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverConformanceTest.java
@@ -344,7 +344,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	private CatalogReference<TestEntity> initializeBoskWithCatalog(Path enclosingCatalogPath) {
 		setupBosksAndReferences(driverFactory);
 		try {
-			CatalogReference<TestEntity> ref = bosk.catalogReference(TestEntity.class, enclosingCatalogPath);
+			CatalogReference<TestEntity> ref = bosk.rootReference().thenCatalog(TestEntity.class, enclosingCatalogPath);
 
 			TestEntity child1 = autoInitialize(ref.then(child1ID));
 			TestEntity child2 = autoInitialize(ref.then(child2ID));


### PR DESCRIPTION
`RootReference` is now the primary factory for `Reference` objects. This PR inlines all uses of the Bosk reference factory methods in preparation for removing them in a future release.