### PR TITLE
MongoDriver manifest document

### DIFF
--- a/bosk-core/src/main/java/io/vena/bosk/ReferenceUtils.java
+++ b/bosk-core/src/main/java/io/vena/bosk/ReferenceUtils.java
@@ -23,6 +23,7 @@ import lombok.experimental.Delegate;
 
 import static io.vena.bosk.util.ReflectionHelpers.setAccessible;
 import static java.lang.String.format;
+import static java.lang.reflect.Modifier.STATIC;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 
@@ -263,6 +264,8 @@ C&lt;String> someField;
 				Method result = c.getDeclaredMethod(methodName);
 				if (result.getParameterCount() != 0) {
 					throw new InvalidTypeException("Getter method \"" + methodName + "\" has unexpected arguments: " + Arrays.toString(result.getParameterTypes()));
+				} else if ((result.getModifiers() & STATIC) != 0) {
+					throw new InvalidTypeException("Getter method \"" + methodName + "\" is static");
 				}
 				return setAccessible(result);
 			} catch (NoSuchMethodException e) {

--- a/bosk-mongo/DEVELOPERS.md
+++ b/bosk-mongo/DEVELOPERS.md
@@ -3,7 +3,7 @@
 This guide is intended for those interested in contributing to the development of the `bosk-mongo` module.
 (The guide for developers _using_ the the module is [USERS.md](../docs/USERS.md).)
 
-### Introduction
+### Introduction and Overview
 
 `MongoDriver` is an implementation of the `BoskDriver` interface,
 which permits users to submit updates to the bosk state.
@@ -31,18 +31,20 @@ In the case of `MongoDriver`, these additional attributes are:
 
 Replication is achieved naturally by MongoDB when two or more `MongoDriver`s connect to the same database,
 since the change stream will include all updates from all drivers; and
-to implement persistence,
-`MongoDriver` reads the initial bosk state from the database during `Bosk` initialization (in the `initialRoot` method).
+persistence is achieved by having
+`MongoDriver` read the initial bosk state from the database during `Bosk` initialization (in the `initialRoot` method).
 
 While conceptually simple, the real complexity lies in fault tolerance.
 An important goal of `MongoDriver` is that if the database is somehow damaged and then repaired,
 `MongoDriver` should recover and resume normal operation without any intervention.
 This means `MongoDriver` must deal with a multitude of error cases and race conditions,
 which add complexity to what would otherwise be a relatively straightforward interaction with MongoDB.
-The MongoDB client library itself does an admirable job of fault tolerance on its own for database reads, writes, and DDL operations;
+The MongoDB client library itself does an admirable job of fault tolerance
+on its own for database reads, writes, and DDL operations;
 but once the change stream is added to the mix, things get complicated,
 because the change stream cannot operate in isolation:
-change stream initialization and error handling must be coordinated with database reads in order to make sure no change events are missed.
+change stream initialization and error handling must be coordinated with database reads
+so that no change events are missed.
 
 To manage this complexity,
 a `MongoDriver` is actually composed of several objects with different responsibilities.
@@ -75,9 +77,9 @@ such as `@ParametersByName` and `@DisruptsMongoService`.
 ### TODO: Points to cover
 (This document is a work in progress.)
 
-- Basic operation
-- Reads always come from memory. That's always true in Bosk, and a driver can't change that even if it wanted to.
-- Driver operations lead to database operations; they are not forwarded downstream
+/ Basic operation
+/ Reads always come from memory. That's always true in Bosk, and a driver can't change that even if it wanted to.
+/ Driver operations lead to database operations; they are not forwarded downstream
 	- Translated from bosk to MongoDB by a `FormatDriver`
 	- `initialRoot` is a special case that will need to be documented separately
 - Change events bring the database operations back to `MongoDriver` via `ChangeReceiver`, which forwards them to `FormatDriver`
@@ -86,12 +88,12 @@ such as `@ParametersByName` and `@DisruptsMongoService`.
 	- You get persistence/durability
 	- You get replication for free!
 - The cursor lifecycle
-- Two different lifetimes: permanent and cursor
 - Responsibilities of the background thread
-- `FormatDriver`
+- Two different lifetimes: permanent and cursor
+/ `FormatDriver`
 - Division of responsibilities from the draft Principles of Operation doc
 - Emphasis on error handling
-- General orientation toward checked exceptions for exceptions that are not visible to the user
+/ General orientation toward checked exceptions for exceptions that are not visible to the user
 - `initialRoot` is complicated; explain why from the block comment
 - Logging philosophy from block comment
 - MongoDB semantics

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/BsonPlugin.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/BsonPlugin.java
@@ -607,7 +607,7 @@ public final class BsonPlugin extends SerializationPlugin {
 			try {
 				getter = LOOKUP.unreflect(getterMethod(nodeClass, name));
 			} catch (IllegalAccessException | InvalidTypeException e1) {
-				throw new IllegalStateException("Eh?", e1);
+				throw new IllegalStateException("Error in class " + nodeClass.getSimpleName() + ": " + e1.getMessage(), e1);
 			}
 			MethodHandle fieldWriter = parameterWriterHandle(nodeClass, name, parameter, codecRegistry, bosk); // (P,W,E)
 			MethodHandle writerCall = filterArguments(fieldWriter, 0, getter); // (N,W,E)

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Formatter.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Formatter.java
@@ -45,7 +45,10 @@ final class Formatter {
 	private final Function<Reference<?>, SerializationPlugin.DeserializationScope> deserializationScopeFunction;
 
 	Formatter(Bosk<?> bosk, BsonPlugin bsonPlugin) {
-		this.simpleCodecs = CodecRegistries.fromProviders(bsonPlugin.codecProviderFor(bosk), new ValueCodecProvider(), new DocumentCodecProvider());
+		this.simpleCodecs = CodecRegistries.fromProviders(
+			bsonPlugin.codecProviderFor(bosk),
+			new ValueCodecProvider(),
+			new DocumentCodecProvider());
 		this.preferredBoskCodecs = type -> bsonPlugin.getCodec(type, rawClass(type), simpleCodecs, bosk);
 		this.deserializationScopeFunction = bsonPlugin::newDeserializationScope;
 	}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
@@ -258,7 +258,7 @@ public class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 	public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
 		doRetryableDriverOperation(()->{
 			formatDriver.submitConditionalReplacement(target, newValue, precondition, requiredValue);
-		}, "submitConditionalReplcament({}, {}={})", target, precondition, requiredValue);
+		}, "submitConditionalReplacement({}, {}={})", target, precondition, requiredValue);
 	}
 
 	@Override

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
@@ -165,7 +165,7 @@ public class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 				preferredDriver.onRevisionToSkip(REVISION_ONE); // initialRoot handles REVISION_ONE; downstream only needs to know about changes after that
 				publishFormatDriver(preferredDriver);
 			} catch (RuntimeException | IOException e2) {
-				LOGGER.debug("Failed to initialize database; disconnecting", e);
+				LOGGER.debug("Failed to initialize database; disconnecting", e2);
 				quietlySetFormatDriver(new DisconnectedDriver<>(e2.toString()));
 			}
 		} catch (RuntimeException | UnrecognizedFormatException | IOException e) {

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
@@ -460,6 +460,7 @@ public class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 	private <X extends Exception, Y extends Exception> void waitAndRetry(RetryableOperation<X, Y> operation, String description, Object... args) throws X, Y {
 		try {
 			formatDriverLock.lock();
+			LOGGER.debug("Waiting for new FormatDriver for {} ms", 5 * driverSettings.recoveryPollingMS());
 			boolean success = formatDriverChanged.await(5*driverSettings.recoveryPollingMS(), MILLISECONDS);
 			if (!success) {
 				LOGGER.debug("Timed out waiting for new FormatDriver; will retry anyway");

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Manifest.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Manifest.java
@@ -1,0 +1,18 @@
+package io.vena.bosk.drivers.mongo;
+
+import io.vena.bosk.StateTreeNode;
+import java.util.Optional;
+import lombok.Value;
+
+@Value
+public class Manifest implements StateTreeNode {
+	Integer version;
+	Optional<EmptyNode> sequoia;
+
+	@Value
+	public static class EmptyNode implements StateTreeNode {}
+
+	public static Manifest forSequoia() {
+		return new Manifest(1, Optional.of(new EmptyNode()));
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriverSettings.java
@@ -25,6 +25,7 @@ public class MongoDriverSettings {
 	@Builder
 	public static class Experimental {
 		@Default long changeStreamInitialWaitMS = 20;
+		@Default ManifestMode manifestMode = ManifestMode.ENABLED;
 	}
 
 	/**
@@ -67,5 +68,10 @@ public class MongoDriverSettings {
 		 * but in production, it creates a boot sequencing dependency between the application and the database.
 		 */
 		FAIL
+	}
+
+	public enum ManifestMode {
+		DISABLED,
+		ENABLED,
 	}
 }

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/SchemaEvolutionTest.java
@@ -3,8 +3,8 @@ package io.vena.bosk.drivers.mongo;
 import io.vena.bosk.Bosk;
 import io.vena.bosk.Reference;
 import io.vena.bosk.annotations.ReferencePath;
-import io.vena.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
 import io.vena.bosk.drivers.mongo.MongoDriverSettings.Experimental;
+import io.vena.bosk.drivers.mongo.MongoDriverSettings.ManifestMode;
 import io.vena.bosk.drivers.state.TestEntity;
 import io.vena.bosk.exceptions.InvalidTypeException;
 import io.vena.bosk.junit.ParametersByName;
@@ -24,9 +24,9 @@ public class SchemaEvolutionTest {
 	private final Helper toHelper;
 
 	@ParametersByName
-	SchemaEvolutionTest(DatabaseFormat fromFormat, DatabaseFormat toFormat) {
-		fromHelper = new Helper(fromFormat);
-		toHelper = new Helper(toFormat);
+	SchemaEvolutionTest(ManifestMode fromMode, ManifestMode toMode) {
+		fromHelper = new Helper(fromMode);
+		toHelper = new Helper(toMode);
 	}
 
 	@BeforeAll
@@ -50,13 +50,13 @@ public class SchemaEvolutionTest {
 	}
 
 	@SuppressWarnings("unused")
-	static Stream<DatabaseFormat> fromFormat() {
-		return Stream.of(DatabaseFormat.values());
+	static Stream<ManifestMode> fromMode() {
+		return Stream.of(ManifestMode.values());
 	}
 
 	@SuppressWarnings("unused")
-	static Stream<DatabaseFormat> toFormat() {
-		return Stream.of(DatabaseFormat.values());
+	static Stream<ManifestMode> toMode() {
+		return fromMode();
 	}
 
 	@ParametersByName
@@ -80,14 +80,14 @@ public class SchemaEvolutionTest {
 	static final class Helper extends AbstractMongoDriverTest {
 		final String name;
 
-		public Helper(DatabaseFormat format) {
+		public Helper(ManifestMode manifestMode) {
 			super(MongoDriverSettings.builder()
 				.database(SchemaEvolutionTest.class.getSimpleName())
-				.preferredDatabaseFormat(format)
 				.experimental(Experimental.builder()
+					.manifestMode(manifestMode)
 					.build())
 			);
-			this.name = format.name();
+			this.name = manifestMode.name();
 		}
 	}
 

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/TestParameters.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/TestParameters.java
@@ -1,6 +1,5 @@
 package io.vena.bosk.drivers.mongo;
 
-import io.vena.bosk.drivers.mongo.MongoDriverSettings.Experimental;
 import io.vena.bosk.drivers.mongo.MongoDriverSettings.MongoDriverSettingsBuilder;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -11,21 +10,16 @@ public interface TestParameters {
 	@SuppressWarnings("unused")
 	static Stream<MongoDriverSettingsBuilder> driverSettings() {
 		String prefix = "boskTestDB_" + dbCounter.incrementAndGet();
-		Experimental resilient = Experimental.builder()
-			.build();
 		return Stream.of(
 			MongoDriverSettings.builder()
 				.database(prefix)
-				.experimental(resilient)
 //			MongoDriverSettings.builder()
 //				.database(prefix + "_slow")
-//				.experimental(resilient)
 //				.testing(MongoDriverSettings.Testing.builder()
 //					.eventDelayMS(200)
 //					.build()),
 //			MongoDriverSettings.builder()
 //				.database(prefix + "_fast")
-//				.experimental(resilient)
 //				.testing(MongoDriverSettings.Testing.builder()
 //					.eventDelayMS(-200)
 //					.build())


### PR DESCRIPTION
As part of #51, this adds support for a "manifest document" that describes the bosk colletion. It's designed to be as future-proof as possible, allowing us to evolve the database format over time, including the manifest format itself, with existing codebases handling incompatibilities in a graceful way.

I've also made it optional as an experimental feature, just to facilitate automated testing of schema volution. (It's enabled by default.)