### PR TITLE
Spring boot configuration metadata

### DIFF
--- a/bosk-spring-boot-3/build.gradle
+++ b/bosk-spring-boot-3/build.gradle
@@ -14,6 +14,7 @@ java {
 dependencies {
 	api project(":bosk-jackson")
 	implementation 'org.springframework.boot:spring-boot-starter-web:3.1.1'
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:3.1.1"
 	testImplementation project(":bosk-testing")
 	testImplementation project(":lib-testing")
 }

--- a/bosk-spring-boot-3/src/main/java/io/vena/bosk/spring/boot/BoskAutoConfiguration.java
+++ b/bosk-spring-boot-3/src/main/java/io/vena/bosk/spring/boot/BoskAutoConfiguration.java
@@ -8,10 +8,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@EnableConfigurationProperties(WebProperties.class)
 public class BoskAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(

--- a/bosk-spring-boot-3/src/main/java/io/vena/bosk/spring/boot/BoskAutoConfiguration.java
+++ b/bosk-spring-boot-3/src/main/java/io/vena/bosk/spring/boot/BoskAutoConfiguration.java
@@ -17,7 +17,6 @@ public class BoskAutoConfiguration {
 	@ConditionalOnProperty(
 		prefix = "bosk.web",
 		name = "read-context",
-		havingValue = "",
 		matchIfMissing = true)
 	@ConditionalOnBean(Bosk.class) // Because of matchIfMissing
 	ReadContextFilter readContextFilter(

--- a/bosk-spring-boot-3/src/main/java/io/vena/bosk/spring/boot/WebProperties.java
+++ b/bosk-spring-boot-3/src/main/java/io/vena/bosk/spring/boot/WebProperties.java
@@ -1,0 +1,13 @@
+package io.vena.bosk.spring.boot;
+
+import lombok.Value;
+import lombok.experimental.Accessors;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "bosk.web")
+@Value
+@Accessors(fluent = false)
+public class WebProperties {
+	Boolean readContext;
+	String servicePath;
+}

--- a/example-hello/build.gradle
+++ b/example-hello/build.gradle
@@ -24,7 +24,6 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // A real project would pull this like any other library


### PR DESCRIPTION
Use the Spring configuration annotation processor to generate a metadata file for the `bosk-spring-boot-3` library.

Note: I have not yet actually witnessed this working correctly in IntelliJ. I'm hoping this is another IntelliJ oddity that might fix itself once the package is published. 🤞 