### PR TITLE
DriverStateVerifier

### DIFF
--- a/bosk-core/src/main/java/io/vena/bosk/Bosk.java
+++ b/bosk-core/src/main/java/io/vena/bosk/Bosk.java
@@ -890,7 +890,7 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 			if (obj == null) {
 				return false;
 			}
-			if (!(obj instanceof ReferenceImpl)) {
+			if (!(obj instanceof Reference)) {
 				return false;
 			}
 
@@ -900,9 +900,9 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 			// if they both have the same root type.
 
 			@SuppressWarnings({"rawtypes", "unchecked"})
-			ReferenceImpl other = (ReferenceImpl) obj;
-			return Objects.equals(this.rootType(), other.rootType())
-				&& Objects.equals(path, other.path);
+			Reference other = (Reference) obj;
+			return Objects.equals(this.rootType(), other.root().targetType())
+				&& Objects.equals(path, other.path());
 		}
 
 		private Type rootType() {

--- a/bosk-core/src/main/java/io/vena/bosk/Bosk.java
+++ b/bosk-core/src/main/java/io/vena/bosk/Bosk.java
@@ -181,6 +181,7 @@ public class Bosk<R extends StateTreeNode> {
 
 		@Override
 		public <T> void submitReplacement(Reference<T> target, T newValue) {
+			assertCorrectBosk(target);
 			synchronized (this) {
 				R priorRoot = currentRoot;
 				if (!tryGraftReplacement(target, newValue)) {
@@ -193,6 +194,7 @@ public class Bosk<R extends StateTreeNode> {
 
 		@Override
 		public <T> void submitInitialization(Reference<T> target, T newValue) {
+			assertCorrectBosk(target);
 			synchronized (this) {
 				boolean preconditionsSatisfied;
 				try (@SuppressWarnings("unused") ReadContext executionContext = new ReadContext(currentRoot)) {
@@ -211,6 +213,7 @@ public class Bosk<R extends StateTreeNode> {
 
 		@Override
 		public <T> void submitDeletion(Reference<T> target) {
+			assertCorrectBosk(target);
 			synchronized (this) {
 				R priorRoot = currentRoot;
 				if (!tryGraftDeletion(target)) {
@@ -229,6 +232,8 @@ public class Bosk<R extends StateTreeNode> {
 
 		@Override
 		public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
+			assertCorrectBosk(target);
+			assertCorrectBosk(precondition);
 			synchronized (this) {
 				boolean preconditionsSatisfied;
 				try (@SuppressWarnings("unused") ReadContext executionContext = new ReadContext(currentRoot)) {
@@ -247,6 +252,8 @@ public class Bosk<R extends StateTreeNode> {
 
 		@Override
 		public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
+			assertCorrectBosk(target);
+			assertCorrectBosk(precondition);
 			synchronized (this) {
 				boolean preconditionsSatisfied;
 				try (@SuppressWarnings("unused") ReadContext executionContext = new ReadContext(currentRoot)) {
@@ -271,6 +278,16 @@ public class Bosk<R extends StateTreeNode> {
 				triggerQueueingOfHooks(rootReference(), null, currentRoot, reg);
 			}
 			drainQueueIfAllowed();
+		}
+
+		private <T> void assertCorrectBosk(Reference<T> target) {
+			// TODO: Do we need to be this strict?
+			// On the one hand, we could write conditional updates in a way that don't require the
+			// reference to point to the right bosk.
+			// On the other hand, there's a certain symmetry to requiring the references to have the right
+			// bosk for both reads and writes, and forcing this discipline on users might help them avoid
+			// some pretty confusing mistakes.
+			assert ((RootRef) target.root()).bosk() == Bosk.this: "Reference supplied to driver operation must refer to the correct bosk";
 		}
 
 		/**
@@ -752,6 +769,8 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 		public RootRef(Type targetType) {
 			super(Path.empty(), targetType);
 		}
+
+		Bosk<?> bosk() { return Bosk.this; }
 
 		@Override
 		public <U> Reference<U> then(Class<U> requestedClass, Path path) throws InvalidTypeException {

--- a/bosk-core/src/main/java/io/vena/bosk/DriverStack.java
+++ b/bosk-core/src/main/java/io/vena/bosk/DriverStack.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
  * Composes multiple {@link DriverFactory} objects into a stack so that they
  * can be instantiated and connected to each other.
  */
-public interface DriverStack<R extends Entity> extends DriverFactory<R> {
+public interface DriverStack<R extends StateTreeNode> extends DriverFactory<R> {
 	/**
 	 * Returns a {@link DriverStack} that composes multiple {@link DriverFactory}
 	 * objects in such a way that each factory is downstream of the one before it.
@@ -20,7 +20,7 @@ public interface DriverStack<R extends Entity> extends DriverFactory<R> {
 	 * @return a factory that composes <code>factories</code> from right to left
 	 */
 	@SafeVarargs
-	static <RR extends Entity> DriverStack<RR> of(DriverFactory<RR>...factories) {
+	static <RR extends StateTreeNode> DriverStack<RR> of(DriverFactory<RR>...factories) {
 		return new DriverStack<RR>() {
 			@Override
 			public BoskDriver<RR> build(Bosk<RR> bosk, BoskDriver<RR> downstream) {

--- a/bosk-core/src/main/java/io/vena/bosk/ReferenceUtils.java
+++ b/bosk-core/src/main/java/io/vena/bosk/ReferenceUtils.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -63,6 +64,15 @@ public final class ReferenceUtils {
 			}
 		}
 
+		@Override public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			} else {
+				return ref.equals(o);
+			}
+		}
+
+		@Override public int hashCode() { return ref.hashCode(); }
 		@Override public String toString() { return ref.toString(); }
 	}
 
@@ -85,6 +95,15 @@ public final class ReferenceUtils {
 			}
 		}
 
+		@Override public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			} else {
+				return ref.equals(o);
+			}
+		}
+
+		@Override public int hashCode() { return ref.hashCode(); }
 		@Override public String toString() { return ref.toString(); }
 	}
 
@@ -111,13 +130,11 @@ public final class ReferenceUtils {
 			return new SideTableRef<>(ref.boundBy(bindings), keyClass(), valueClass());
 		}
 
-		@Override public boolean equals(Object obj) {
-			if (obj == this) {
+		@Override public boolean equals(Object o) {
+			if (this == o) {
 				return true;
-			} else if (obj instanceof Reference) {
-				return obj.equals(ref);
 			} else {
-				return false;
+				return ref.equals(o);
 			}
 		}
 

--- a/bosk-core/src/main/java/io/vena/bosk/drivers/MirroringDriver.java
+++ b/bosk-core/src/main/java/io/vena/bosk/drivers/MirroringDriver.java
@@ -21,11 +21,21 @@ import static lombok.AccessLevel.PRIVATE;
 public class MirroringDriver<R extends StateTreeNode> implements BoskDriver<R> {
 	private final Bosk<R> mirror;
 
+	/**
+	 * Causes updates to be applied both to <code>mirror</code> and to the downstream driver.
+	 */
 	public static <RR extends StateTreeNode> DriverFactory<RR> targeting(Bosk<RR> mirror) {
 		return (bosk, downstream) -> new ForwardingDriver<>(asList(
 			new MirroringDriver<>(mirror),
 			downstream
 		));
+	}
+
+	/**
+	 * Causes updates to be applied only to <code>other</code>.
+	 */
+	public static <RR extends StateTreeNode> MirroringDriver<RR> redirectingTo(Bosk<RR> other) {
+		return new MirroringDriver<>(other);
 	}
 
 	@Override

--- a/bosk-core/src/main/java/io/vena/bosk/drivers/MirroringDriver.java
+++ b/bosk-core/src/main/java/io/vena/bosk/drivers/MirroringDriver.java
@@ -3,9 +3,9 @@ package io.vena.bosk.drivers;
 import io.vena.bosk.Bosk;
 import io.vena.bosk.BoskDriver;
 import io.vena.bosk.DriverFactory;
-import io.vena.bosk.Entity;
 import io.vena.bosk.Identifier;
 import io.vena.bosk.Reference;
+import io.vena.bosk.StateTreeNode;
 import io.vena.bosk.exceptions.InvalidTypeException;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -18,10 +18,10 @@ import static lombok.AccessLevel.PRIVATE;
  * Sends events to another {@link Bosk} of the same type.
  */
 @RequiredArgsConstructor(access=PRIVATE)
-public class MirroringDriver<R extends Entity> implements BoskDriver<R> {
+public class MirroringDriver<R extends StateTreeNode> implements BoskDriver<R> {
 	private final Bosk<R> mirror;
 
-	public static <RR extends Entity> DriverFactory<RR> targeting(Bosk<RR> mirror) {
+	public static <RR extends StateTreeNode> DriverFactory<RR> targeting(Bosk<RR> mirror) {
 		return (bosk, downstream) -> new ForwardingDriver<>(asList(
 			new MirroringDriver<>(mirror),
 			downstream

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
@@ -246,6 +246,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 	private void onManifestEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
 		if (event.getOperationType() == INSERT) {
 			BsonDocument manifest = requireNonNull(event.getFullDocument());
+			manifest.remove("_id");
 			try {
 				formatter.validateManifest(manifest);
 			} catch (UnrecognizedFormatException e) {

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
@@ -200,6 +200,11 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 		}
 		switch (event.getOperationType()) {
 			case INSERT: case REPLACE: {
+				// Note: an INSERT could be coming from this very bosk initializing the collection,
+				// in which case replacing the entire bosk state downstream is unnecessary.
+				// However, it could also be coming from another bosk, or even a human operator doing
+				// a repair, so we can't ignore it either.
+				// It seems unavoidable to pass the change downstream.
 				BsonDocument fullDocument = event.getFullDocument();
 				if (fullDocument == null) {
 					throw new UnprocessableEventException("Missing fullDocument", event.getOperationType());

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverConformanceTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverConformanceTest.java
@@ -30,11 +30,11 @@ class MongoDriverConformanceTest extends DriverConformanceTest {
 	static Stream<MongoDriverSettingsBuilder> driverSettings() {
 		return TestParameters.driverSettings(
 			Stream.of(
-				SEQUOIA,
 				PandoFormat.oneBigDocument(),
 				PandoFormat.withSeparateCollections("/catalog", "/sideTable"), // Basic
 				PandoFormat.withSeparateCollections("/catalog/-x-/sideTable", "/sideTable/-x-/catalog", "/sideTable/-x-/sideTable/-y-/catalog"), // Nesting, parameters
-				PandoFormat.withSeparateCollections("/sideTable/-x-/sideTable/-y-/catalog") // Multiple parameters in the not-separated part
+				PandoFormat.withSeparateCollections("/sideTable/-x-/sideTable/-y-/catalog"), // Multiple parameters in the not-separated part
+				SEQUOIA
 			),
 			Stream.of(EventTiming.NORMAL) // EARLY is slow; LATE is really slow
 		);

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverDottedFieldNameTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverDottedFieldNameTest.java
@@ -2,7 +2,6 @@ package io.vena.bosk.drivers.mongo;
 
 import io.vena.bosk.Bosk;
 import io.vena.bosk.CatalogReference;
-import io.vena.bosk.Identifier;
 import io.vena.bosk.Path;
 import io.vena.bosk.Reference;
 import io.vena.bosk.drivers.AbstractDriverTest;
@@ -24,11 +23,7 @@ class MongoDriverDottedFieldNameTest extends AbstractDriverTest {
 
 	@BeforeEach
 	void setUpStuff() {
-		bosk = new Bosk<TestEntity>("Test bosk", TestEntity.class, this::initialRoot, Bosk::simpleDriver);
-	}
-
-	private TestEntity initialRoot(Bosk<TestEntity> testEntityBosk) throws InvalidTypeException {
-		return TestEntity.empty(Identifier.from("root"), rootCatalogRef(testEntityBosk));
+		bosk = new Bosk<TestEntity>("Test bosk", TestEntity.class, AbstractDriverTest::initialRoot, Bosk::simpleDriver);
 	}
 
 	private CatalogReference<TestEntity> rootCatalogRef(Bosk<TestEntity> bosk) throws InvalidTypeException {

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverResiliencyTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverResiliencyTest.java
@@ -54,8 +54,8 @@ public class MongoDriverResiliencyTest extends AbstractMongoDriverTest {
 	static Stream<MongoDriverSettings.MongoDriverSettingsBuilder> driverSettings() {
 		return TestParameters.driverSettings(
 			Stream.of(
-				SEQUOIA,
-				PandoFormat.withSeparateCollections("/catalog", "/sideTable")
+				PandoFormat.withSeparateCollections("/catalog", "/sideTable"),
+				SEQUOIA
 			),
 			Stream.of(EventTiming.NORMAL)
 		).map(b -> b

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverResiliencyTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverResiliencyTest.java
@@ -187,6 +187,9 @@ public class MongoDriverResiliencyTest extends AbstractMongoDriverTest {
 			collection.deleteMany(rootDocumentFilter);
 		}, (b) -> {
 			LOGGER.debug("Restore original document");
+			// NOTE: This doesn't actually work cleanly with Pando, because restoring the root document by itself
+			// doesn't cause all the subparts to appear in the change stream, which means there's not enough
+			// info to reassemble the whole state tree. It ends up failing and reinitializing, so it passes the test.
 			collection.insertOne(originalDocument.get());
 			return b;
 		});

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/TestParameters.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/TestParameters.java
@@ -21,7 +21,9 @@ public class TestParameters {
 					.preferredDatabaseFormat(f)
 					.recoveryPollingMS(3000) // Note that some tests can take as long as 10x this
 					.flushTimeoutMS(4000) // A little more than recoveryPollingMS
-					.testing(MongoDriverSettings.Testing.builder().eventDelayMS(e.eventDelayMS).build())
+					.testing(MongoDriverSettings.Testing.builder()
+						.eventDelayMS(e.eventDelayMS)
+						.build())
 					.database(MongoDriverResiliencyTest.class.getSimpleName()
 						+ "_" + dbCounter.incrementAndGet()
 						+ "_" + f.getClass().getSimpleName()

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/AbstractDriverTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractDriverTest {
 		// This is the bosk we're testing
 		bosk = new Bosk<TestEntity>("Test bosk", TestEntity.class, AbstractDriverTest::initialRoot, DriverStack.of(
 			MirroringDriver.targeting(canonicalBosk),
-			driverFactory
+			DriverStateVerifier.wrap(driverFactory, TestEntity.class, AbstractDriverTest::initialRoot)
 		));
 		driver = bosk.driver();
 	}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/AbstractDriverTest.java
@@ -58,7 +58,7 @@ public abstract class AbstractDriverTest {
 		driver = bosk.driver();
 	}
 
-	private static TestEntity initialRoot(Bosk<TestEntity> b) throws InvalidTypeException {
+	public static TestEntity initialRoot(Bosk<TestEntity> b) throws InvalidTypeException {
 		return TestEntity.empty(Identifier.from("root"), b.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
 	}
 

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverConformanceTest.java
@@ -1,7 +1,6 @@
 package io.vena.bosk.drivers;
 
 import io.vena.bosk.Bosk;
-import io.vena.bosk.BoskDriver;
 import io.vena.bosk.Catalog;
 import io.vena.bosk.CatalogReference;
 import io.vena.bosk.DriverFactory;
@@ -46,20 +45,20 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	protected DriverFactory<TestEntity> driverFactory;
 
 	@ParametersByName
-	void testInitialState(Path enclosingCatalogPath) {
+	void initialState(Path enclosingCatalogPath) {
 		initializeBoskWithCatalog(enclosingCatalogPath);
 		assertCorrectBoskContents();
 	}
 
 	@ParametersByName
-	void testReplaceIdentical(Path enclosingCatalogPath, Identifier childID) throws InvalidTypeException {
+	void replaceIdentical(Path enclosingCatalogPath, Identifier childID) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		driver.submitReplacement(ref.then(childID), newEntity(childID, ref));
 		assertCorrectBoskContents();
 	}
 
 	@ParametersByName
-	void testReplaceDifferent(Path enclosingCatalogPath, Identifier childID) throws InvalidTypeException {
+	void replaceDifferent(Path enclosingCatalogPath, Identifier childID) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		driver.submitReplacement(ref.then(childID), newEntity(childID, ref)
 			.withString("replaced"));
@@ -67,7 +66,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testReplaceWholeThenParts(Path enclosingCatalogPath, Identifier childID) throws InvalidTypeException {
+	void replaceWholeThenParts(Path enclosingCatalogPath, Identifier childID) throws InvalidTypeException {
 		CatalogReference<TestEntity> catalogRef = initializeBoskWithCatalog(enclosingCatalogPath);
 		Identifier awkwardID = Identifier.from(AWKWARD_ID);
 		Reference<TestEntity> wholeEntityRef = catalogRef.then(awkwardID);
@@ -102,14 +101,14 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testDelete(Path enclosingCatalogPath, Identifier childID) {
+	void delete(Path enclosingCatalogPath, Identifier childID) {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		driver.submitDeletion(ref.then(childID));
 		assertCorrectBoskContents();
 	}
 
 	@ParametersByName
-	void testReplaceCatalog(Path enclosingCatalogPath) throws InvalidTypeException {
+	void replaceCatalog(Path enclosingCatalogPath) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		Identifier unique = Identifier.unique("child");
 		driver.submitReplacement(ref, Catalog.of(
@@ -121,14 +120,14 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testReplaceCatalogEmpty(Path enclosingCatalogPath) {
+	void replaceCatalogEmpty(Path enclosingCatalogPath) {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		driver.submitReplacement(ref, Catalog.empty());
 		assertCorrectBoskContents();
 	}
 
 	@ParametersByName
-	void testConditionalReplaceFirst(Path enclosingCatalogPath) throws InvalidTypeException {
+	void conditionalReplaceFirst(Path enclosingCatalogPath) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		Reference<Identifier> child1IDRef = ref.then(child1ID).then(Identifier.class, TestEntity.Fields.id);
 		Reference<Identifier> child2IDRef = ref.then(child2ID).then(Identifier.class, TestEntity.Fields.id);
@@ -164,7 +163,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testDeleteForward(Path enclosingCatalogPath) {
+	void deleteForward(Path enclosingCatalogPath) {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		driver.submitDeletion(ref.then(child1ID));
 		assertCorrectBoskContents();
@@ -173,7 +172,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testDeleteBackward(Path enclosingCatalogPath) {
+	void deleteBackward(Path enclosingCatalogPath) {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		assertCorrectBoskContents();
 		LOGGER.debug("Delete second child");
@@ -185,7 +184,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testConditionalDelete(Path enclosingCatalogPath) throws InvalidTypeException {
+	void conditionalDelete(Path enclosingCatalogPath) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		Reference<Identifier> child1IDRef = ref.then(child1ID).then(Identifier.class, TestEntity.Fields.id);
 		Reference<Identifier> child2IDRef = ref.then(child2ID).then(Identifier.class, TestEntity.Fields.id);
@@ -221,7 +220,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testDeleteNonexistent(Path enclosingCatalogPath) throws InvalidTypeException {
+	void deleteNonexistent(Path enclosingCatalogPath) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		driver.submitDeletion(ref.then(Identifier.from("nonexistent")));
 		assertCorrectBoskContents();
@@ -230,7 +229,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testDeleteCatalog_fails(Path enclosingCatalogPath) {
+	void deleteCatalog_fails(Path enclosingCatalogPath) {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		assertThrows(IllegalArgumentException.class, ()->
 			driver.submitDeletion(ref));
@@ -238,7 +237,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testDeleteFields_fails(Path enclosingCatalogPath) throws InvalidTypeException {
+	void deleteFields_fails(Path enclosingCatalogPath) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		// Use loops instead of parameters to avoid unnecessarily creating and initializing
 		// a new bosk for every case. None of them affect the bosk anyway.
@@ -253,7 +252,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testOptional() throws InvalidTypeException {
+	void optional() throws InvalidTypeException {
 		Reference<TestValues> ref = initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
 		assertCorrectBoskContents();
 		driver.submitReplacement(ref, TestValues.blank().withString("changed"));
@@ -270,7 +269,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testString() throws InvalidTypeException {
+	void string() throws InvalidTypeException {
 		Reference<TestValues> ref = initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
 		Reference<String> stringRef = ref.then(String.class, TestValues.Fields.string);
 		LOGGER.debug("Submitting changed string");
@@ -284,7 +283,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testEnum() throws InvalidTypeException {
+	void enumeration() throws InvalidTypeException {
 		Reference<TestValues> ref = initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
 		assertCorrectBoskContents();
 		Reference<ChronoUnit> enumRef = ref.then(ChronoUnit.class, TestValues.Fields.chronoUnit);
@@ -298,7 +297,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testListValue() throws InvalidTypeException {
+	void listValue_works() throws InvalidTypeException {
 		Reference<TestValues> ref = initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
 		Reference<ListValue<String>> listRef = ref.then(listValue(String.class), TestValues.Fields.list);
 		driver.submitReplacement(listRef, ListValue.of("this", "that"));
@@ -313,7 +312,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testMapValue() throws InvalidTypeException {
+	void mapValue_works() throws InvalidTypeException {
 		Reference<TestValues> ref = initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
 		Reference<MapValue<String>> mapRef = ref.then(mapValue(String.class), TestValues.Fields.map);
 
@@ -346,7 +345,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void testFlushNothing() throws IOException, InterruptedException {
+	void flushNothing() throws IOException, InterruptedException {
 		setupBosksAndReferences(driverFactory);
 		// Flush before any writes should work
 		driver.flush();

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverConformanceTest.java
@@ -220,6 +220,19 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
+	void replaceNonexistentField(Path enclosingCatalogPath) throws InvalidTypeException {
+		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
+		driver.submitReplacement(
+			ref.then(String.class, "nonexistent", "string"),
+			"new value");
+		assertCorrectBoskContents();
+		driver.submitReplacement(
+			ref.then(String.class, "nonexistent", TestEntity.Fields.catalog, "nonexistent2", "string"),
+			"new value");
+		assertCorrectBoskContents();
+	}
+
+	@ParametersByName
 	void deleteNonexistent(Path enclosingCatalogPath) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		driver.submitDeletion(ref.then(Identifier.from("nonexistent")));

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverStateVerifier.java
@@ -1,0 +1,182 @@
+package io.vena.bosk.drivers;
+
+import io.vena.bosk.Bosk;
+import io.vena.bosk.BoskDriver;
+import io.vena.bosk.DriverFactory;
+import io.vena.bosk.DriverStack;
+import io.vena.bosk.Reference;
+import io.vena.bosk.StateTreeNode;
+import io.vena.bosk.drivers.operations.UpdateOperation;
+import io.vena.bosk.exceptions.InvalidTypeException;
+import io.vena.bosk.exceptions.NotYetImplementedException;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingDeque;
+import lombok.RequiredArgsConstructor;
+import lombok.var;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.lang.Thread.currentThread;
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * Watches the updates entering and leaving a particular {@link BoskDriver} and ensures
+ * that they have the same effect on the bosk state. If a mismatch is found, throws
+ * {@link AssertionError}.
+ *
+ * <p>
+ * Note: this verifier uses {@link Object#equals} to compare parts of the state tree,
+ * expecting value-based equality. If used with state tree nodes having different equality
+ * semantics, the resulting verifier could be more or less strict than expected.
+ */
+@RequiredArgsConstructor(access = PRIVATE)
+public class DriverStateVerifier<R extends StateTreeNode> {
+	/**
+	 * Used to model the effect of each operation on the bosk state
+	 */
+	final Bosk<R> stateTrackingBosk;
+
+	/**
+	 * Unlike {@link #stateTrackingBosk}.{@link Bosk#driver() driver()},
+	 * this driver can accept updates with references pointing to a different bosk with the same root type.
+	 */
+	final BoskDriver<R> stateTrackingDriver;
+
+	final Map<Thread, Deque<UpdateOperation>> pendingOperations = new ConcurrentHashMap<>();
+
+	public static <RR extends StateTreeNode> DriverFactory<RR> wrap(DriverFactory<RR> subject, Type rootType, Bosk.DefaultRootFunction<RR> defaultRootFunction) {
+		Bosk<RR> stateTrackingBosk = new Bosk<>(
+			"Tracking",
+			rootType, defaultRootFunction,
+			Bosk::simpleDriver
+		);
+		DriverStateVerifier<RR> verifier = new DriverStateVerifier<>(
+			stateTrackingBosk,
+			MirroringDriver.redirectingTo(stateTrackingBosk)
+		);
+		return DriverStack.of(
+			ReportingDriver.factory(verifier::incomingUpdate, verifier::incomingFlush),
+			subject,
+			ReportingDriver.factory(verifier::outgoingUpdate, verifier::outgoingFlush)
+		);
+	}
+
+	/**
+	 * Called when an update is about to be sent to the subject driver.
+	 * Thread-safe and non-blocking.
+	 */
+	private void incomingUpdate(UpdateOperation updateOperation) {
+		LOGGER.debug("---> IN: {}", updateOperation);
+		// Note: because we have a separate queue for each thread, this isn't actually blocking
+		pendingOperations
+			.computeIfAbsent(currentThread(), t -> new LinkedBlockingDeque<>())
+			.addLast(updateOperation);
+	}
+
+	private void incomingFlush() {
+		LOGGER.debug("incomingFlush()");
+	}
+
+	/**
+	 * Called when an update has been sent downstream from the subject driver.
+	 * Synchronized not only to protect the integrity of data structures,
+	 * but also to establish the canonical order in which updates are applied.
+	 */
+	private synchronized void outgoingUpdate(UpdateOperation op) {
+		LOGGER.debug("---> OUT: {}", op);
+		try {
+			Object before = currentStateBefore(op);
+			Object after = hypotheticalStateAfter(op);
+			LOGGER.trace("\t\tbefore: {}", before);
+			LOGGER.trace("\t\t after: {}", after);
+
+			for (var e : pendingOperations.entrySet()) {
+				Thread thread = e.getKey();
+				Deque<UpdateOperation> q = e.getValue();
+				LOGGER.trace("\tChecking {} with {} queued operations", thread.getName(), q.size());
+				for (UpdateOperation expected : q) {
+					Object expectedBefore = currentStateBefore(expected); // May not equal `before` if the two operations have different targets
+					Object expectedAfter = hypotheticalStateAfter(expected);
+					LOGGER.trace("\t\texpectedAfter: {}", expectedAfter);
+					if (op.matchesIfApplied(expected) && Objects.equals(after, expectedAfter)) {
+						LOGGER.debug("\tConclusion: found match: {}", expected);
+						UpdateOperation discarded;
+						while ((discarded = q.removeFirst()) != expected) {
+							LOGGER.trace("\t\tdiscard preceding no-op: {}", discarded);
+						}
+						expected.submitTo(stateTrackingDriver);
+						return;
+					} else if (Objects.equals(expectedBefore, expectedAfter)) {
+						LOGGER.trace("\t\tSkip queued no-op: {}", expected);
+					} else {
+						LOGGER.trace("\t\tNo match on thread {}: {}", thread.getName(), expected);
+						break;
+					}
+				}
+			}
+
+			if (Objects.equals(before, after)) {
+				LOGGER.debug("\tConclusion: dropped no-op: {}", op);
+				return;
+			} else {
+				throw new AssertionError("No matching operation\n\t" + op);
+			}
+		} catch (IOException | InterruptedException e) {
+			throw new NotYetImplementedException(e);
+		}
+	}
+
+	private void outgoingFlush() {
+		LOGGER.debug("outgoingFlush()");
+		pendingOperations.forEach((thread, q) -> {
+			if (!q.isEmpty()) {
+				throw new AssertionError(q.size() + " pending operations remain on thread " + thread.getName()
+					+ "\n\tFirst is: " + q.getFirst());
+			}
+		});
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> T currentStateBefore(UpdateOperation op) throws IOException, InterruptedException {
+		Reference<T> stateTrackingRef = (Reference<T>) stateTrackingRef(op.target());
+		stateTrackingBosk.driver().flush();
+		try (var __ = stateTrackingBosk.readContext()) {
+			return stateTrackingRef.valueIfExists();
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> T hypotheticalStateAfter(UpdateOperation op) throws IOException, InterruptedException {
+		T before;
+		R originalState;
+		Reference<T> stateTrackingRef = (Reference<T>) stateTrackingRef(op.target());
+		stateTrackingBosk.driver().flush();
+		try (var __ = stateTrackingBosk.readContext()) {
+			originalState = stateTrackingBosk.rootReference().value();
+			before = stateTrackingRef.valueIfExists();
+		}
+		op.submitTo(stateTrackingDriver);
+		stateTrackingBosk.driver().flush();
+		try (var __ = stateTrackingBosk.readContext()) {
+			return stateTrackingRef.valueIfExists();
+		} finally {
+			stateTrackingBosk.driver().submitReplacement(stateTrackingBosk.rootReference(), originalState);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> Reference<T> stateTrackingRef(Reference<T> original) {
+		try {
+			return (Reference<T>) stateTrackingBosk.rootReference().then(Object.class, original.path());
+		} catch (InvalidTypeException e) {
+			throw new AssertionError("References are expected to be compatible: " + original, e);
+		}
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DriverStateVerifier.class);
+}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/ReportingDriver.java
@@ -1,0 +1,76 @@
+package io.vena.bosk.drivers;
+
+import io.vena.bosk.BoskDriver;
+import io.vena.bosk.DriverFactory;
+import io.vena.bosk.Identifier;
+import io.vena.bosk.Reference;
+import io.vena.bosk.StateTreeNode;
+import io.vena.bosk.drivers.operations.SubmitConditionalDeletion;
+import io.vena.bosk.drivers.operations.SubmitConditionalReplacement;
+import io.vena.bosk.drivers.operations.SubmitDeletion;
+import io.vena.bosk.drivers.operations.SubmitInitialization;
+import io.vena.bosk.drivers.operations.SubmitReplacement;
+import io.vena.bosk.drivers.operations.UpdateOperation;
+import io.vena.bosk.exceptions.InvalidTypeException;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.function.Consumer;
+
+/**
+ * Sends an {@link UpdateOperation} to a given listener whenever one of the update methods is called.
+ */
+public class ReportingDriver<R extends StateTreeNode> implements BoskDriver<R> {
+	final BoskDriver<R> downstream;
+	final Consumer<UpdateOperation> updateListener;
+	final Runnable flushListener;
+
+	private ReportingDriver(BoskDriver<R> downstream, Consumer<UpdateOperation> updateListener, Runnable flushListener) {
+		this.downstream = downstream;
+		this.updateListener = updateListener;
+		this.flushListener = flushListener;
+	}
+
+	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Consumer<UpdateOperation> listener, Runnable flushListener) {
+		return (b,d) -> new ReportingDriver<>(d, listener, flushListener);
+	}
+
+	@Override
+	public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+		return downstream.initialRoot(rootType);
+	}
+
+	@Override
+	public <T> void submitReplacement(Reference<T> target, T newValue) {
+		updateListener.accept(new SubmitReplacement<>(target, newValue));
+		downstream.submitReplacement(target, newValue);
+	}
+
+	@Override
+	public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
+		updateListener.accept(new SubmitConditionalReplacement<>(target, newValue, precondition, requiredValue));
+		downstream.submitConditionalReplacement(target, newValue, precondition, requiredValue);
+	}
+
+	@Override
+	public <T> void submitInitialization(Reference<T> target, T newValue) {
+		updateListener.accept(new SubmitInitialization<>(target, newValue));
+		downstream.submitInitialization(target, newValue);
+	}
+
+	@Override
+	public <T> void submitDeletion(Reference<T> target) {
+		updateListener.accept(new SubmitDeletion<>(target));
+		downstream.submitDeletion(target);
+	}
+
+	@Override
+	public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
+		updateListener.accept(new SubmitConditionalDeletion<>(target, precondition, requiredValue));
+		downstream.submitConditionalDeletion(target, precondition, requiredValue);
+	}
+
+	@Override
+	public void flush() throws IOException, InterruptedException {
+		downstream.flush();
+	}
+}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/ConditionalOperation.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/ConditionalOperation.java
@@ -1,0 +1,13 @@
+package io.vena.bosk.drivers.operations;
+
+import io.vena.bosk.Identifier;
+import io.vena.bosk.Reference;
+
+/**
+ * Doesn't include {@link SubmitInitialization}.
+ */
+public interface ConditionalOperation extends UpdateOperation {
+	Reference<Identifier> precondition();
+	Identifier requiredValue();
+	UpdateOperation unconditional();
+}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/DeletionOperation.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/DeletionOperation.java
@@ -1,0 +1,12 @@
+package io.vena.bosk.drivers.operations;
+
+public interface DeletionOperation<T> extends UpdateOperation {
+	@Override
+	default boolean matchesIfApplied(UpdateOperation other) {
+		if (other instanceof DeletionOperation) {
+			return this.target().equals(other.target());
+		} else {
+			return false;
+		}
+	}
+}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/ReplacementOperation.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/ReplacementOperation.java
@@ -1,0 +1,15 @@
+package io.vena.bosk.drivers.operations;
+
+public interface ReplacementOperation<T> extends UpdateOperation {
+	T newValue();
+
+	@Override
+	default boolean matchesIfApplied(UpdateOperation other) {
+		if (other instanceof ReplacementOperation) {
+			return this.target().equals(other.target())
+				&& this.newValue().equals(((ReplacementOperation<?>) other).newValue());
+		} else {
+			return false;
+		}
+	}
+}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalDeletion.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalDeletion.java
@@ -1,0 +1,23 @@
+package io.vena.bosk.drivers.operations;
+
+import io.vena.bosk.BoskDriver;
+import io.vena.bosk.Identifier;
+import io.vena.bosk.Reference;
+import lombok.Value;
+
+@Value
+public class SubmitConditionalDeletion<T> implements DeletionOperation<T>, ConditionalOperation {
+	Reference<T> target;
+	Reference<Identifier> precondition;
+	Identifier requiredValue;
+
+	@Override
+	public SubmitDeletion<T> unconditional() {
+		return new SubmitDeletion<>(target);
+	}
+
+	@Override
+	public void submitTo(BoskDriver<?> driver) {
+		driver.submitConditionalDeletion(target, precondition, requiredValue);
+	}
+}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalReplacement.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalReplacement.java
@@ -1,0 +1,24 @@
+package io.vena.bosk.drivers.operations;
+
+import io.vena.bosk.BoskDriver;
+import io.vena.bosk.Identifier;
+import io.vena.bosk.Reference;
+import lombok.Value;
+
+@Value
+public class SubmitConditionalReplacement<T> implements ReplacementOperation<T>, ConditionalOperation {
+	Reference<T> target;
+	T newValue;
+	Reference<Identifier> precondition;
+	Identifier requiredValue;
+
+	@Override
+	public SubmitReplacement<T> unconditional() {
+		return new SubmitReplacement<>(target, newValue);
+	}
+
+	@Override
+	public void submitTo(BoskDriver<?> driver) {
+		driver.submitConditionalReplacement(target, newValue, precondition, requiredValue);
+	}
+}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitDeletion.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitDeletion.java
@@ -1,0 +1,15 @@
+package io.vena.bosk.drivers.operations;
+
+import io.vena.bosk.BoskDriver;
+import io.vena.bosk.Reference;
+import lombok.Value;
+
+@Value
+public class SubmitDeletion<T> implements DeletionOperation<T> {
+	Reference<T> target;
+
+	@Override
+	public void submitTo(BoskDriver<?> driver) {
+		driver.submitDeletion(target);
+	}
+}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitInitialization.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitInitialization.java
@@ -1,0 +1,16 @@
+package io.vena.bosk.drivers.operations;
+
+import io.vena.bosk.BoskDriver;
+import io.vena.bosk.Reference;
+import lombok.Value;
+
+@Value
+public class SubmitInitialization<T> implements ReplacementOperation<T> {
+	Reference<T> target;
+	T newValue;
+
+	@Override
+	public void submitTo(BoskDriver<?> driver) {
+		driver.submitInitialization(target, newValue);
+	}
+}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitReplacement.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitReplacement.java
@@ -1,0 +1,16 @@
+package io.vena.bosk.drivers.operations;
+
+import io.vena.bosk.BoskDriver;
+import io.vena.bosk.Reference;
+import lombok.Value;
+
+@Value
+public class SubmitReplacement<T> implements ReplacementOperation<T> {
+	Reference<T> target;
+	T newValue;
+
+	@Override
+	public void submitTo(BoskDriver<?> driver) {
+		driver.submitReplacement(target, newValue);
+	}
+}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/UpdateOperation.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/UpdateOperation.java
@@ -1,0 +1,10 @@
+package io.vena.bosk.drivers.operations;
+
+import io.vena.bosk.BoskDriver;
+import io.vena.bosk.Reference;
+
+public interface UpdateOperation {
+	Reference<?> target();
+	boolean matchesIfApplied(UpdateOperation other);
+	void submitTo(BoskDriver<?> driver);
+}

--- a/bosk-testing/src/test/java/io/vena/bosk/drivers/ReportingDriverTest.java
+++ b/bosk-testing/src/test/java/io/vena/bosk/drivers/ReportingDriverTest.java
@@ -1,0 +1,140 @@
+package io.vena.bosk.drivers;
+
+import io.vena.bosk.Identifier;
+import io.vena.bosk.ListingEntry;
+import io.vena.bosk.Reference;
+import io.vena.bosk.annotations.ReferencePath;
+import io.vena.bosk.drivers.operations.SubmitConditionalDeletion;
+import io.vena.bosk.drivers.operations.SubmitConditionalReplacement;
+import io.vena.bosk.drivers.operations.SubmitDeletion;
+import io.vena.bosk.drivers.operations.SubmitInitialization;
+import io.vena.bosk.drivers.operations.SubmitReplacement;
+import io.vena.bosk.drivers.operations.UpdateOperation;
+import io.vena.bosk.drivers.state.TestEntity;
+import io.vena.bosk.exceptions.InvalidTypeException;
+import io.vena.bosk.exceptions.NotYetImplementedException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.var;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.vena.bosk.ListingEntry.LISTING_ENTRY;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReportingDriverTest extends AbstractDriverTest {
+	List<UpdateOperation> ops;
+	AtomicInteger numFlushes;
+	Refs refs;
+	final Identifier id1 = Identifier.from("id1");
+	final Identifier id2 = Identifier.from("id2");
+
+	public interface Refs {
+		@ReferencePath("/id")                  Reference<Identifier> id();
+		@ReferencePath("/listing/-id-")        Reference<ListingEntry> entry(Identifier id);
+		@ReferencePath("/catalog/-id-")        Reference<TestEntity> entity(Identifier id);
+		@ReferencePath("/catalog/-id-/string") Reference<String> string(Identifier id);
+	}
+
+	@BeforeEach
+	void setUp() throws InvalidTypeException {
+		ops = new ArrayList<>();
+		numFlushes = new AtomicInteger(0);
+		setupBosksAndReferences(ReportingDriver.factory(ops::add, numFlushes::incrementAndGet));
+		refs = bosk.buildReferences(Refs.class);
+		bosk.driver().submitReplacement(refs.entity(id1), emptyEntityAt(refs.entity(id1)));
+		ops.clear();
+	}
+
+	@Test
+	void initialRoot() {
+		assertExpectedEvents();
+		assertCorrectBoskContents();
+	}
+
+	@Test
+	void submitReplacement() {
+		Reference<String> ref = refs.string(id1);
+		String newValue = "submitReplacement";
+		bosk.driver().submitReplacement(ref, newValue);
+		assertExpectedEvents(new SubmitReplacement<>(ref, newValue));
+		assertNodeEquals(newValue, ref);
+		assertCorrectBoskContents();
+	}
+
+	@Test
+	void submitConditionalReplacement() {
+		Reference<String> ref = refs.string(id1);
+		String newValue = "submitConditionalReplacement";
+		Reference<Identifier> precondition = refs.id();
+		Identifier requiredValue = Identifier.from("root");
+		bosk.driver().submitConditionalReplacement(ref, newValue, precondition, requiredValue);
+		assertExpectedEvents(new SubmitConditionalReplacement<>(ref, newValue, precondition, requiredValue));
+		assertNodeEquals(newValue, ref);
+		assertCorrectBoskContents();
+	}
+
+	@Test
+	void submitInitialization() {
+		Reference<TestEntity> ref = refs.entity(id2);
+		TestEntity newValue = emptyEntityAt(ref);
+		bosk.driver().submitInitialization(ref, newValue);
+		assertExpectedEvents(new SubmitInitialization<>(ref, newValue));
+		assertNodeEquals(newValue, ref);
+		assertCorrectBoskContents();
+	}
+
+	@Test
+	void submitDeletion() {
+		Reference<ListingEntry> ref = refs.entry(id1);
+		bosk.driver().submitReplacement(ref, LISTING_ENTRY);
+		assertExpectedEvents(new SubmitReplacement<>(ref, LISTING_ENTRY));
+		assertNodeEquals(LISTING_ENTRY, ref);
+		assertCorrectBoskContents();
+
+		ops.clear();
+		bosk.driver().submitDeletion(ref);
+		assertExpectedEvents(new SubmitDeletion<>(ref));
+		assertNodeEquals(null, ref);
+		assertCorrectBoskContents();
+	}
+
+	@Test
+	void submitConditionalDeletion() {
+		Reference<ListingEntry> ref = refs.entry(id1);
+		bosk.driver().submitReplacement(ref, LISTING_ENTRY);
+		assertExpectedEvents(new SubmitReplacement<>(ref, LISTING_ENTRY));
+		assertNodeEquals(LISTING_ENTRY, ref);
+		assertCorrectBoskContents();
+
+		ops.clear();
+		Reference<Identifier> precondition = refs.id();
+		Identifier requiredValue = Identifier.from("root");
+		bosk.driver().submitConditionalDeletion(ref, precondition, requiredValue);
+		assertExpectedEvents(new SubmitConditionalDeletion<>(ref, precondition, requiredValue));
+		assertNodeEquals(null, ref);
+		assertCorrectBoskContents();
+	}
+
+	@Test
+	void flush() {
+	}
+
+	private void assertExpectedEvents(UpdateOperation... expectedOps) {
+		try {
+			bosk.driver().flush();
+		} catch (IOException | InterruptedException e) {
+			throw new NotYetImplementedException(e);
+		}
+		assertEquals(asList(expectedOps), this.ops);
+	}
+
+	private <T> void assertNodeEquals(T expectedValue, Reference<T> location) {
+		try (var __  = bosk.readContext()) {
+			assertEquals(expectedValue, location.valueIfExists());
+		}
+	}
+}


### PR DESCRIPTION
### Main change

The headliner is `DriverStateVerifier`. This component observes the events sent to / received from a `BoskDriver` and ensures that the outgoing events are consistent with the incoming ones. `AbstractDriverTest` (which includes `DriverConformanceTest`) now wraps the tested driver in a `DriverStateVerifier` to make sure it's propagating events correctly.

This turned out to be difficult when multiple threads are involved. Drivers are permitted to make certain changes to the event stream (as long as they have the same effect on the bosk state), and this, combined with figuring out the right interleaving of events from multiple threads _based solely on the effect they had_, turned out to be difficult.

I'm planning to take a break from this and implement a context propagation system, which I want anyway, and which will allow me to determine the source thread for each event, greatly simplifying the verification process.

### Additional changes
- Fixed `Reference` comparison so a `Reference` and `CatalogReference` to the same node will compare equal; similar for `Listing` and `SideTable` references
- Fixed Sequoia to remove the `_id` field from manifest document change stream event before processing it, thus silencing a warning about it being unexpected and ignored
- Fixed a couple of vestigial dependencies on `Entity` which should be `StateTreeNode`
- Added `DriverConformanceTest.replaceNonexistentField`
- Created `ReportingDriver`, which emits "event objects" for each driver operation