### PR TITLE
Fix "delete existing" conformance test

### DIFF
--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
@@ -30,9 +30,9 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import lombok.var;
 import org.bson.BsonDocument;
-import org.bson.BsonInt32;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
+import org.bson.BsonValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -358,9 +358,23 @@ public class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 
 		@Override
 		public void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
-			LOGGER.debug("onEvent({})", event.getOperationType().getValue());
+			LOGGER.debug("onEvent({}:{})", event.getOperationType().getValue(), getDocumentKeyValue(event));
 			LOGGER.trace("Event details: {}", event);
 			formatDriver.onEvent(event);
+		}
+
+		private Object getDocumentKeyValue(ChangeStreamDocument<BsonDocument> event) {
+			BsonDocument documentKey = event.getDocumentKey();
+			if (documentKey == null) {
+				return null;
+			} else  {
+				BsonValue value = documentKey.get("_id");
+				if (value instanceof BsonString) {
+					return value.asString().getValue();
+				} else {
+					return value;
+				}
+			}
 		}
 
 		@Override

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverConformanceTest.java
@@ -101,8 +101,12 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void delete(Path enclosingCatalogPath, Identifier childID) {
+	void deleteExisting(Path enclosingCatalogPath) {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
+		// Here, we surgically initialize just the one child we want to delete, for a little variety.
+		// Once upon a time, MongoDriver failed this specific case.
+		Identifier childID = Identifier.unique("child");
+		autoInitialize(ref.then(childID));
 		driver.submitDeletion(ref.then(childID));
 		assertCorrectBoskContents();
 	}


### PR DESCRIPTION
The conformance test had a test for deleting an object, but we weren't properly initializing the bosk state, so it was just testing the "delete nonexistent" case.

Also, I found that `PandoFormatDriver` has different behaviour based on whether the object was added on its own versus as part of the containing catalog, so I added it on its own in the new test to make sure that case was covered.