### PR TITLE
Diagnostic context propagation

### DIFF
--- a/bosk-core/src/main/java/io/vena/bosk/BoskDiagnosticContext.java
+++ b/bosk-core/src/main/java/io/vena/bosk/BoskDiagnosticContext.java
@@ -1,0 +1,71 @@
+package io.vena.bosk;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A thread-local set of name-value pairs that propagate all the way from
+ * submission of a driver update, through all the driver layers,
+ * to the execution of hooks.
+ */
+public final class BoskDiagnosticContext {
+	private final ThreadLocal<MapValue<String>> currentAttributes = ThreadLocal.withInitial(MapValue::empty);
+
+	public final class DiagnosticScope implements AutoCloseable {
+		final MapValue<String> oldAttributes = currentAttributes.get();
+
+		DiagnosticScope(MapValue<String> attributes) {
+			currentAttributes.set(attributes);
+		}
+
+		@Override
+		public void close() {
+			currentAttributes.set(oldAttributes);
+		}
+	}
+
+	/**
+	 * @return the current thread's value of the attribute with the given <code>name</code>,
+	 * or <code>null</code> if no such attribute has been defined.
+	 */
+	public @Nullable String getAttribute(String name) {
+		return currentAttributes.get().get(name);
+	}
+
+	public @NotNull MapValue<String> getAttributes() {
+		return currentAttributes.get();
+	}
+
+	/**
+	 * Adds a single attribute to the current thread's diagnostic context.
+	 * If the attribute already exists, it will be replaced.
+	 */
+	public DiagnosticScope withAttribute(String name, String value) {
+		return new DiagnosticScope(currentAttributes.get().with(name, value));
+	}
+
+	/**
+	 * Adds attributes to the current thread's diagnostic context.
+	 * If an attribute already exists, it will be replaced.
+	 */
+	public DiagnosticScope withAttributes(@NotNull MapValue<String> additionalAttributes) {
+		return new DiagnosticScope(currentAttributes.get().withAll(additionalAttributes));
+	}
+
+	/**
+	 * Replaces all attributes in the current thread's diagnostic context.
+	 * Existing attributes are removed/replaced.
+	 * <p>
+	 * This is intended for propagating context from one thread to another.
+	 * <p>
+	 * If <code>attributes</code> is null, this is a no-op, and any existing attributes on this thread are retained.
+	 * If ensuring a clean set of attributes is important, pass an empty map instead of null.
+	 */
+	public DiagnosticScope withOnly(@Nullable MapValue<String> attributes) {
+		if (attributes == null) {
+			return new DiagnosticScope(currentAttributes.get());
+		} else {
+			return new DiagnosticScope(attributes);
+		}
+	}
+}

--- a/bosk-core/src/main/java/io/vena/bosk/MapValue.java
+++ b/bosk-core/src/main/java/io/vena/bosk/MapValue.java
@@ -86,6 +86,10 @@ public final class MapValue<V> implements Map<String, V> {
 		}
 	}
 
+	public MapValue<V> withAll(Map<String, ? extends V> m) {
+		return new MapValue<>(contents.plusAll(m));
+	}
+
 	@Override
 	public String toString() {
 		return contents.toString();

--- a/bosk-core/src/main/java/io/vena/bosk/RootReference.java
+++ b/bosk-core/src/main/java/io/vena/bosk/RootReference.java
@@ -42,4 +42,5 @@ public interface RootReference<R> extends Reference<R> {
 	<K extends Entity,V> SideTableReference<K,V> thenSideTable(Class<K> keyClass, Class<V> valueClass, Path path) throws InvalidTypeException;
 	<T> Reference<Reference<T>> thenReference(Class<T> targetClass, Path path) throws InvalidTypeException;
 
+	BoskDiagnosticContext diagnosticContext();
 }

--- a/bosk-core/src/test/java/io/vena/bosk/BoskDiagnosticContextTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/BoskDiagnosticContextTest.java
@@ -1,0 +1,54 @@
+package io.vena.bosk;
+
+import io.vena.bosk.annotations.ReferencePath;
+import io.vena.bosk.drivers.AbstractDriverTest;
+import io.vena.bosk.drivers.state.TestEntity;
+import io.vena.bosk.exceptions.InvalidTypeException;
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.var;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Note that context propagation for driver operations is tested by {@link io.vena.bosk.drivers.DriverConformanceTest}.
+ */
+class BoskDiagnosticContextTest extends AbstractDriverTest {
+	Refs refs;
+
+	public interface Refs {
+		@ReferencePath("/string") Reference<String> string();
+	}
+
+	@BeforeEach
+	void setupBosk() throws InvalidTypeException {
+		bosk = new Bosk<TestEntity>(
+			BoskDiagnosticContextTest.class.getSimpleName(),
+			TestEntity.class,
+			AbstractDriverTest::initialRoot,
+			Bosk::simpleDriver
+		);
+		refs = bosk.buildReferences(Refs.class);
+	}
+
+	@Test
+	void hookRegistration_propagatesDiagnosticContext() throws IOException, InterruptedException {
+		Semaphore diagnosticsVerified = new Semaphore(0);
+		bosk.driver().flush();
+		try (var __ = bosk.diagnosticContext().withAttribute("attributeName", "attributeValue")) {
+			bosk.registerHook("contextPropagatesToHook", bosk.rootReference(), ref -> {
+				assertEquals("attributeValue", bosk.diagnosticContext().getAttribute("attributeName"));
+				assertEquals(MapValue.singleton("attributeName", "attributeValue"), bosk.diagnosticContext().getAttributes());
+				diagnosticsVerified.release();
+			});
+		}
+		bosk.driver().flush();
+		assertTrue(diagnosticsVerified.tryAcquire(5, SECONDS));
+	}
+
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Formatter.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Formatter.java
@@ -1,5 +1,7 @@
 package io.vena.bosk.drivers.mongo;
 
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import com.mongodb.client.model.changestream.UpdateDescription;
 import io.vena.bosk.Bosk;
 import io.vena.bosk.Listing;
 import io.vena.bosk.Reference;
@@ -203,6 +205,29 @@ final class Formatter {
 			return objectCodec.decode(reader, DecoderContext.builder().build());
 		}
 	}
+
+	BsonInt64 getRevisionFromFullDocument(BsonDocument fullDocument) {
+		if (fullDocument == null) {
+			return null;
+		}
+		return fullDocument.getInt64(DocumentFields.revision.name(), null);
+	}
+
+	BsonInt64 getRevisionFromUpdateEvent(ChangeStreamDocument<BsonDocument> event) {
+		if (event == null) {
+			return null;
+		}
+		UpdateDescription updateDescription = event.getUpdateDescription();
+		if (updateDescription == null) {
+			return null;
+		}
+		BsonDocument updatedFields = updateDescription.getUpdatedFields();
+		if (updatedFields == null) {
+			return null;
+		}
+		return updatedFields.getInt64(DocumentFields.revision.name(), null);
+	}
+
 
 	/**
 	 * @return MongoDB field name corresponding to the given Reference

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Formatter.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Formatter.java
@@ -4,6 +4,7 @@ import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.UpdateDescription;
 import io.vena.bosk.Bosk;
 import io.vena.bosk.Listing;
+import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
 import io.vena.bosk.SerializationPlugin;
 import io.vena.bosk.SideTable;
@@ -17,6 +18,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.Function;
@@ -28,6 +30,7 @@ import org.bson.BsonDocumentWriter;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
 import org.bson.BsonReader;
+import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
@@ -94,6 +97,7 @@ final class Formatter {
 		path,
 		state,
 		revision,
+		diagnostics,
 	}
 
 	private final BsonInt32 SUPPORTED_MANIFEST_VERSION = new BsonInt32(1);
@@ -170,6 +174,22 @@ final class Formatter {
 				DecoderContext.builder().build());
 	}
 
+	BsonDocument encodeDiagnostics(MapValue<String> attributes) {
+		BsonDocument result = new BsonDocument();
+		attributes.forEach((name, value) -> result.put(name, new BsonString(value)));
+		return new BsonDocument("attributes", result);
+	}
+
+	MapValue<String> decodeDiagnosticAttributes(BsonDocument diagnostics) {
+		MapValue<String> result = MapValue.empty();
+		for (Map.Entry<String, BsonValue> foo: diagnostics.getDocument("attributes").entrySet()) {
+			String name = foo.getKey();
+			String value = foo.getValue().asString().getValue();
+			result = result.with(name, value);
+		}
+		return result;
+	}
+
 	/**
 	 * @see #bsonValue2object(BsonValue, Reference)
 	 */
@@ -213,6 +233,17 @@ final class Formatter {
 		return fullDocument.getInt64(DocumentFields.revision.name(), null);
 	}
 
+	MapValue<String> getDiagnosticAttributesFromFullDocument(BsonDocument fullDocument) {
+		if (fullDocument == null) {
+			return null;
+		}
+		BsonDocument diagnostics = fullDocument.getDocument(DocumentFields.diagnostics.name(), null);
+		if (diagnostics == null) {
+			return null;
+		}
+		return decodeDiagnosticAttributes(diagnostics);
+	}
+
 	BsonInt64 getRevisionFromUpdateEvent(ChangeStreamDocument<BsonDocument> event) {
 		if (event == null) {
 			return null;
@@ -228,6 +259,24 @@ final class Formatter {
 		return updatedFields.getInt64(DocumentFields.revision.name(), null);
 	}
 
+	MapValue<String> getDiagnosticAttributesFromUpdateEvent(ChangeStreamDocument<BsonDocument> event) {
+		if (event == null) {
+			return null;
+		}
+		UpdateDescription updateDescription = event.getUpdateDescription();
+		if (updateDescription == null) {
+			return null;
+		}
+		BsonDocument updatedFields = updateDescription.getUpdatedFields();
+		if (updatedFields == null) {
+			return null;
+		}
+		BsonDocument diagnostics = updatedFields.getDocument(DocumentFields.diagnostics.name(), null);
+		if (diagnostics == null) {
+			return null;
+		}
+		return decodeDiagnosticAttributes(diagnostics);
+	}
 
 	/**
 	 * @return MongoDB field name corresponding to the given Reference

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/PandoFormatDriver.java
@@ -286,7 +286,7 @@ final class PandoFormatDriver<R extends StateTreeNode> implements FormatDriver<R
 					throw new UnprocessableEventException("Missing fullDocument on final event", finalEvent.getOperationType());
 				}
 
-				BsonInt64 revision = getRevisionFromFullDocumentEvent(fullDocument);
+				BsonInt64 revision = formatter.getRevisionFromFullDocument(fullDocument);
 				if (shouldSkip(revision)) {
 					LOGGER.debug("Skipping revision {}", revision.longValue());
 					return;
@@ -306,7 +306,7 @@ final class PandoFormatDriver<R extends StateTreeNode> implements FormatDriver<R
 			} break;
 			case UPDATE: {
 				// TODO: Combine code with INSERT and REPLACE events
-				BsonInt64 revision = getRevisionFromUpdateEvent(finalEvent);
+				BsonInt64 revision = formatter.getRevisionFromUpdateEvent(finalEvent);
 				if (shouldSkip(revision)) {
 					LOGGER.debug("Skipping revision {}", revision.longValue());
 					return;
@@ -447,33 +447,6 @@ final class PandoFormatDriver<R extends StateTreeNode> implements FormatDriver<R
 		LOGGER.debug("+ onRevisionToSkip({})", revision.longValue());
 		revisionToSkip = revision;
 		flushLock.finishedRevision(revision);
-	}
-
-	private BsonInt64 getRevisionFromFullDocumentEvent(BsonDocument fullDocument) {
-		if (fullDocument == null) {
-			return null;
-		}
-		BsonValue revision = fullDocument.get(DocumentFields.revision.name());
-		if (revision == null) {
-			return null;
-		} else {
-			return revision.asInt64();
-		}
-	}
-
-	private static BsonInt64 getRevisionFromUpdateEvent(ChangeStreamDocument<BsonDocument> event) {
-		if (event == null) {
-			return null;
-		}
-		UpdateDescription updateDescription = event.getUpdateDescription();
-		if (updateDescription == null) {
-			return null;
-		}
-		BsonDocument updatedFields = updateDescription.getUpdatedFields();
-		if (updatedFields == null) {
-			return null;
-		}
-		return updatedFields.getInt64(DocumentFields.revision.name(), null);
 	}
 
 	private static boolean updateEventHasField(ChangeStreamDocument<BsonDocument> event, DocumentFields field) {

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/PandoFormatDriver.java
@@ -15,6 +15,7 @@ import io.vena.bosk.BoskDriver;
 import io.vena.bosk.Entity;
 import io.vena.bosk.EnumerableByIdentifier;
 import io.vena.bosk.Identifier;
+import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
 import io.vena.bosk.RootReference;
 import io.vena.bosk.StateTreeNode;
@@ -33,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import lombok.NonNull;
+import lombok.var;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
@@ -193,17 +195,18 @@ final class PandoFormatDriver<R extends StateTreeNode> implements FormatDriver<R
 			throw new IllegalStateException("Cannot locate root document");
 		}
 		BsonValue revision = mainPart.get(DocumentFields.revision.name(), REVISION_ZERO);
+		MapValue<String> diagnosticAttributes = formatter.getDiagnosticAttributesFromFullDocument(mainPart);
 
 		BsonDocument combinedState = bsonSurgeon.gather(allParts);
 		R root = formatter.document2object(combinedState, rootRef);
-		return new StateAndMetadata<>(root, revision.asInt64());
+		return new StateAndMetadata<>(root, revision.asInt64(), diagnosticAttributes);
 	}
 
 	@Override
 	public void initializeCollection(StateAndMetadata<R> priorContents) {
 		BsonValue initialState = formatter.object2bsonValue(priorContents.state, rootRef.targetType());
 		BsonInt64 newRevision = new BsonInt64(1 + priorContents.revision.longValue());
-
+		// Note that priorContents.diagnosticAttributes are ignored, and we use the attributes from this thread
 
 		LOGGER.debug("** Initial upsert for {}", ROOT_DOCUMENT_ID.getValue());
 		collection.ensureTransactionStarted();
@@ -292,14 +295,17 @@ final class PandoFormatDriver<R extends StateTreeNode> implements FormatDriver<R
 					return;
 				}
 
-				BsonDocument state = fullDocument.getDocument(DocumentFields.state.name());
-				if (state == null) {
-					ChangeStreamDocument<BsonDocument> mainEvent = events.get(events.size() - 2);
-					LOGGER.debug("Main event is {} on {}", mainEvent.getOperationType(), mainEvent.getDocumentKey());
-					propagateDownstream(mainEvent, events.subList(0, events.size() - 2));
-				} else {
-					LOGGER.debug("Main event is final event");
-					propagateDownstream(finalEvent, events.subList(0, events.size() - 1));
+				MapValue<String> diagnosticAttributes = formatter.getDiagnosticAttributesFromFullDocument(fullDocument);
+				try (var __ = rootRef.diagnosticContext().withOnly(diagnosticAttributes)) {
+					BsonDocument state = fullDocument.getDocument(DocumentFields.state.name());
+					if (state == null) {
+						ChangeStreamDocument<BsonDocument> mainEvent = events.get(events.size() - 2);
+						LOGGER.debug("Main event is {} on {}", mainEvent.getOperationType(), mainEvent.getDocumentKey());
+						propagateDownstream(mainEvent, events.subList(0, events.size() - 2));
+					} else {
+						LOGGER.debug("Main event is final event");
+						propagateDownstream(finalEvent, events.subList(0, events.size() - 1));
+					}
 				}
 
 				flushLock.finishedRevision(revision);
@@ -311,16 +317,19 @@ final class PandoFormatDriver<R extends StateTreeNode> implements FormatDriver<R
 					LOGGER.debug("Skipping revision {}", revision.longValue());
 					return;
 				}
-				boolean mainEventIsFinalEvent = updateEventHasField(finalEvent, DocumentFields.state); // If the final update changes only the revision field, then it's not the main event
-				if (mainEventIsFinalEvent) {
-					LOGGER.debug("Main event is final event");
-					propagateDownstream(finalEvent, events.subList(0, events.size() - 1));
-				} else if (events.size() < 2) {
-					LOGGER.debug("Main event is a no-op");
-				} else {
-					ChangeStreamDocument<BsonDocument> mainEvent = events.get(events.size() - 2);
-					LOGGER.debug("Main event is {} on {}", mainEvent.getOperationType(), mainEvent.getDocumentKey());
-					propagateDownstream(mainEvent, events.subList(0, events.size() - 2));
+				MapValue<String> attributes = formatter.getDiagnosticAttributesFromUpdateEvent(finalEvent);
+				try (var __ = rootRef.diagnosticContext().withOnly(attributes)) {
+					boolean mainEventIsFinalEvent = updateEventHasField(finalEvent, DocumentFields.state); // If the final update changes only the revision field, then it's not the main event
+					if (mainEventIsFinalEvent) {
+						LOGGER.debug("Main event is final event");
+						propagateDownstream(finalEvent, events.subList(0, events.size() - 1));
+					} else if (events.size() < 2) {
+						LOGGER.debug("Main event is a no-op");
+					} else {
+						ChangeStreamDocument<BsonDocument> mainEvent = events.get(events.size() - 2);
+						LOGGER.debug("Main event is {} on {}", mainEvent.getOperationType(), mainEvent.getDocumentKey());
+						propagateDownstream(mainEvent, events.subList(0, events.size() - 2));
+					}
 				}
 				flushLock.finishedRevision(revision);
 			} break;
@@ -700,8 +709,15 @@ final class PandoFormatDriver<R extends StateTreeNode> implements FormatDriver<R
 	private <T> BsonDocument replacementDoc(Reference<T> target, BsonValue value, Reference<?> startingRef) {
 		String key = dottedFieldNameOf(target, startingRef);
 		LOGGER.debug("| Set field {}: {}", key, value);
-		return blankUpdateDoc()
-			.append("$set", new BsonDocument(key, value));
+		BsonDocument result = blankUpdateDoc();
+		result.compute("$set", (__,existing) -> {
+			if (existing == null) {
+				return new BsonDocument(key, value);
+			} else {
+				return existing.asDocument().append(key, value);
+			}
+		});
+		return result;
 	}
 
 	private <T> BsonDocument deletionDoc(Reference<T> target, Reference<?> startingRef) {
@@ -711,7 +727,8 @@ final class PandoFormatDriver<R extends StateTreeNode> implements FormatDriver<R
 	}
 
 	private BsonDocument blankUpdateDoc() {
-		return new BsonDocument("$inc", new BsonDocument(DocumentFields.revision.name(), new BsonInt64(1)));
+		return new BsonDocument("$inc", new BsonDocument(DocumentFields.revision.name(), new BsonInt64(1)))
+			.append("$set", new BsonDocument(DocumentFields.diagnostics.name(), formatter.encodeDiagnostics(rootRef.diagnosticContext().getAttributes())));
 	}
 
 	private BsonDocument initialDocument(BsonValue initialState, BsonInt64 revision) {
@@ -720,6 +737,7 @@ final class PandoFormatDriver<R extends StateTreeNode> implements FormatDriver<R
 		fieldValues.put(DocumentFields.path.name(), new BsonString("/"));
 		fieldValues.put(DocumentFields.state.name(), initialState);
 		fieldValues.put(DocumentFields.revision.name(), revision);
+		fieldValues.put(DocumentFields.diagnostics.name(), formatter.encodeDiagnostics(rootRef.diagnosticContext().getAttributes()));
 
 		return fieldValues;
 	}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
@@ -11,7 +11,9 @@ import com.mongodb.lang.Nullable;
 import io.vena.bosk.Bosk;
 import io.vena.bosk.BoskDriver;
 import io.vena.bosk.Identifier;
+import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
+import io.vena.bosk.RootReference;
 import io.vena.bosk.StateTreeNode;
 import io.vena.bosk.drivers.mongo.Formatter.DocumentFields;
 import io.vena.bosk.exceptions.FlushFailureException;
@@ -22,6 +24,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.var;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
 import org.bson.BsonNull;
@@ -52,7 +55,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 	private final MongoDriverSettings settings;
 	private final Formatter formatter;
 	private final MongoCollection<BsonDocument> collection;
-	private final Reference<R> rootRef;
+	private final RootReference<R> rootRef;
 	private final BoskDriver<R> downstream;
 	private final FlushLock flushLock;
 
@@ -136,11 +139,12 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 			BsonDocument document = cursor.next();
 			BsonDocument state = document.getDocument(DocumentFields.state.name(), null);
 			BsonInt64 revision = document.getInt64(DocumentFields.revision.name(), REVISION_ZERO);
+			MapValue<String> diagnosticAttributes = formatter.getDiagnosticAttributesFromFullDocument(document);
 			if (state == null) {
 				throw new IOException("No existing state in document");
 			} else {
 				R root = formatter.document2object(state, rootRef);
-				return new StateAndMetadata<>(root, revision);
+				return new StateAndMetadata<>(root, revision, diagnosticAttributes);
 			}
 		} catch (NoSuchElementException e) {
 			throw new UninitializedCollectionException("No existing document", e);
@@ -152,6 +156,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 	public void initializeCollection(StateAndMetadata<R> priorContents) {
 		BsonValue initialState = formatter.object2bsonValue(priorContents.state, rootRef.targetType());
 		BsonInt64 newRevision = new BsonInt64(1 + priorContents.revision.longValue());
+		// Note that priorContents.diagnosticAttributes are ignored, and we use the attributes from this thread
 		BsonDocument update = new BsonDocument("$set", initialDocument(initialState, newRevision));
 		BsonDocument filter = documentFilter();
 		UpdateOptions options = new UpdateOptions().upsert(true);
@@ -219,7 +224,10 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 				// saves us in MongoDriverResiliencyTest.documentReappears_recovers because when the doc
 				// disappears, we don't null out revisionToSkip. TODO: Rethink what's the right way to handle this.
 				LOGGER.debug("| Replace {}", rootRef);
-				downstream.submitReplacement(rootRef, newRoot);
+				MapValue<String> diagnosticAttributes = formatter.getDiagnosticAttributesFromFullDocument(fullDocument);
+				try (var __ = rootRef.diagnosticContext().withOnly(diagnosticAttributes)) {
+					downstream.submitReplacement(rootRef, newRoot);
+				}
 				flushLock.finishedRevision(revision);
 			} break;
 			case UPDATE: {
@@ -227,8 +235,11 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 				if (updateDescription != null) {
 					BsonInt64 revision = formatter.getRevisionFromUpdateEvent(event);
 					if (shouldNotSkip(revision)) {
-						replaceUpdatedFields(updateDescription.getUpdatedFields());
-						deleteRemovedFields(updateDescription.getRemovedFields(), event.getOperationType());
+						MapValue<String> attributes = formatter.getDiagnosticAttributesFromUpdateEvent(event);
+						try (var __ = rootRef.diagnosticContext().withOnly(attributes)) {
+							replaceUpdatedFields(updateDescription.getUpdatedFields());
+							deleteRemovedFields(updateDescription.getRemovedFields(), event.getOperationType());
+						}
 					}
 					flushLock.finishedRevision(revision);
 				}
@@ -340,8 +351,15 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 		String key = dottedFieldNameOf(target, rootRef);
 		BsonValue value = formatter.object2bsonValue(newValue, target.targetType());
 		LOGGER.debug("| Set field {}: {}", key, value);
-		return updateDoc()
-			.append("$set", new BsonDocument(key, value));
+		BsonDocument result = updateDoc();
+		result.compute("$set", (__,existing) -> {
+			if (existing == null) {
+				return new BsonDocument(key, value);
+			} else {
+				return existing.asDocument().append(key, value);
+			}
+		});
+		return result;
 	}
 
 	private <T> BsonDocument deletionDoc(Reference<T> target) {
@@ -351,7 +369,8 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 	}
 
 	private BsonDocument updateDoc() {
-		return new BsonDocument("$inc", new BsonDocument(DocumentFields.revision.name(), new BsonInt64(1)));
+		return new BsonDocument("$inc", new BsonDocument(DocumentFields.revision.name(), new BsonInt64(1)))
+			.append("$set", new BsonDocument(DocumentFields.diagnostics.name(), formatter.encodeDiagnostics(rootRef.diagnosticContext().getAttributes())));
 	}
 
 	private BsonDocument initialDocument(BsonValue initialState, BsonInt64 revision) {
@@ -360,6 +379,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 		fieldValues.put(DocumentFields.path.name(), new BsonString("/"));
 		fieldValues.put(DocumentFields.state.name(), initialState);
 		fieldValues.put(DocumentFields.revision.name(), revision);
+		fieldValues.put(DocumentFields.diagnostics.name(), formatter.encodeDiagnostics(rootRef.diagnosticContext().getAttributes()));
 
 		return fieldValues;
 	}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
@@ -209,7 +209,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 				if (fullDocument == null) {
 					throw new UnprocessableEventException("Missing fullDocument", event.getOperationType());
 				}
-				BsonInt64 revision = getRevisionFromFullDocumentEvent(fullDocument);
+				BsonInt64 revision = formatter.getRevisionFromFullDocument(fullDocument);
 				BsonDocument state = fullDocument.getDocument(DocumentFields.state.name(), null);
 				if (state == null) {
 					throw new UnprocessableEventException("Missing state field", event.getOperationType());
@@ -225,7 +225,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 			case UPDATE: {
 				UpdateDescription updateDescription = event.getUpdateDescription();
 				if (updateDescription != null) {
-					BsonInt64 revision = getRevisionFromUpdateEvent(event);
+					BsonInt64 revision = formatter.getRevisionFromUpdateEvent(event);
 					if (shouldNotSkip(revision)) {
 						replaceUpdatedFields(updateDescription.getUpdatedFields());
 						deleteRemovedFields(updateDescription.getRemovedFields(), event.getOperationType());
@@ -271,28 +271,6 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 		LOGGER.debug("+ onRevisionToSkip({})", revision.longValue());
 		revisionToSkip = revision;
 		flushLock.finishedRevision(revision);
-	}
-
-	private BsonInt64 getRevisionFromFullDocumentEvent(BsonDocument fullDocument) {
-		if (fullDocument == null) {
-			return null;
-		}
-		return fullDocument.getInt64(DocumentFields.revision.name(), null);
-	}
-
-	private static BsonInt64 getRevisionFromUpdateEvent(ChangeStreamDocument<BsonDocument> event) {
-		if (event == null) {
-			return null;
-		}
-		UpdateDescription updateDescription = event.getUpdateDescription();
-		if (updateDescription == null) {
-			return null;
-		}
-		BsonDocument updatedFields = updateDescription.getUpdatedFields();
-		if (updatedFields == null) {
-			return null;
-		}
-		return updatedFields.getInt64(DocumentFields.revision.name(), null);
 	}
 
 	//

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/StateAndMetadata.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/StateAndMetadata.java
@@ -1,5 +1,6 @@
 package io.vena.bosk.drivers.mongo;
 
+import io.vena.bosk.MapValue;
 import io.vena.bosk.StateTreeNode;
 import lombok.RequiredArgsConstructor;
 import org.bson.BsonInt64;
@@ -8,4 +9,5 @@ import org.bson.BsonInt64;
 class StateAndMetadata<R extends StateTreeNode> {
 	final R state;
 	final BsonInt64 revision;
+	final MapValue<String> diagnosticAttributes;
 }


### PR DESCRIPTION
Added a thread-local map of key-value string pairs that can be used to pass context information through the driver stack.

This will enable all kinds of observability, but more immediately, it will allow me to get `DriverStateVerifier` working really solidly without needing to infer which thread each update came from because I can use diagnostic attributes to label them.