### PR TITLE
Use diagnostic attribute to pass thread name in `DriverStateVerifier`

### DIFF
--- a/bosk-core/src/main/java/io/vena/bosk/drivers/DiagnosticScopeDriver.java
+++ b/bosk-core/src/main/java/io/vena/bosk/drivers/DiagnosticScopeDriver.java
@@ -1,0 +1,81 @@
+package io.vena.bosk.drivers;
+
+import io.vena.bosk.BoskDiagnosticContext;
+import io.vena.bosk.BoskDiagnosticContext.DiagnosticScope;
+import io.vena.bosk.BoskDriver;
+import io.vena.bosk.DriverFactory;
+import io.vena.bosk.Identifier;
+import io.vena.bosk.Reference;
+import io.vena.bosk.StateTreeNode;
+import io.vena.bosk.exceptions.InvalidTypeException;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import lombok.var;
+
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * Automatically sets a {@link DiagnosticScope} around each driver operation based on a user-supplied function.
+ * Allows diagnostic context to be supplied automatically to every operation.
+ */
+@RequiredArgsConstructor(access = PRIVATE)
+public class DiagnosticScopeDriver<R extends StateTreeNode> implements BoskDriver<R> {
+	final BoskDriver<R> downstream;
+	final BoskDiagnosticContext diagnosticContext;
+	final Function<BoskDiagnosticContext, DiagnosticScope> scopeSupplier;
+
+	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Function<BoskDiagnosticContext, DiagnosticScope> scopeSupplier) {
+		return (b,d) -> new DiagnosticScopeDriver<>(d, b.diagnosticContext(), scopeSupplier);
+	}
+
+	@Override
+	public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+		try (var __ = scopeSupplier.apply(diagnosticContext)) {
+			return downstream.initialRoot(rootType);
+		}
+	}
+
+	@Override
+	public <T> void submitReplacement(Reference<T> target, T newValue) {
+		try (var __ = scopeSupplier.apply(diagnosticContext)) {
+			downstream.submitReplacement(target, newValue);
+		}
+	}
+
+	@Override
+	public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
+		try (var __ = scopeSupplier.apply(diagnosticContext)) {
+			downstream.submitConditionalReplacement(target, newValue, precondition, requiredValue);
+		}
+	}
+
+	@Override
+	public <T> void submitInitialization(Reference<T> target, T newValue) {
+		try (var __ = scopeSupplier.apply(diagnosticContext)) {
+			downstream.submitInitialization(target, newValue);
+		}
+	}
+
+	@Override
+	public <T> void submitDeletion(Reference<T> target) {
+		try (var __ = scopeSupplier.apply(diagnosticContext)) {
+			downstream.submitDeletion(target);
+		}
+	}
+
+	@Override
+	public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
+		try (var __ = scopeSupplier.apply(diagnosticContext)) {
+			downstream.submitConditionalDeletion(target, precondition, requiredValue);
+		}
+	}
+
+	@Override
+	public void flush() throws IOException, InterruptedException {
+		try (var __ = scopeSupplier.apply(diagnosticContext)) {
+			downstream.flush();
+		}
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/ChangeListener.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/ChangeListener.java
@@ -15,7 +15,6 @@ interface ChangeListener {
 		TimeoutException;
 
 	void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException;
-
 	void onConnectionFailed(Exception e) throws InterruptedException, InitialRootActionException, TimeoutException;
 	void onDisconnect(Throwable e);
 }

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/FormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/FormatDriver.java
@@ -20,6 +20,8 @@ import org.bson.BsonInt64;
  *     Processing change stream events via {@link #onEvent}
  * </li><li>
  *     Implementing {@link #flush()} (consider using {@link FlushLock})
+ * </li><li>
+ *     Propagating {@link io.vena.bosk.BoskDiagnosticContext diagnostic context} downstream.
  * </li></ol>
  *
  * Implementations are not responsible for:

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/PandoFormatDriver.java
@@ -295,7 +295,7 @@ final class PandoFormatDriver<R extends StateTreeNode> implements FormatDriver<R
 					return;
 				}
 
-				MapValue<String> diagnosticAttributes = formatter.getDiagnosticAttributesFromFullDocument(fullDocument);
+				MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromFullDocument(fullDocument);
 				try (var __ = rootRef.diagnosticContext().withOnly(diagnosticAttributes)) {
 					BsonDocument state = fullDocument.getDocument(DocumentFields.state.name());
 					if (state == null) {
@@ -317,7 +317,7 @@ final class PandoFormatDriver<R extends StateTreeNode> implements FormatDriver<R
 					LOGGER.debug("Skipping revision {}", revision.longValue());
 					return;
 				}
-				MapValue<String> attributes = formatter.getDiagnosticAttributesFromUpdateEvent(finalEvent);
+				MapValue<String> attributes = formatter.eventDiagnosticAttributesFromUpdate(finalEvent);
 				try (var __ = rootRef.diagnosticContext().withOnly(attributes)) {
 					boolean mainEventIsFinalEvent = updateEventHasField(finalEvent, DocumentFields.state); // If the final update changes only the revision field, then it's not the main event
 					if (mainEventIsFinalEvent) {

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
@@ -224,7 +224,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 				// saves us in MongoDriverResiliencyTest.documentReappears_recovers because when the doc
 				// disappears, we don't null out revisionToSkip. TODO: Rethink what's the right way to handle this.
 				LOGGER.debug("| Replace {}", rootRef);
-				MapValue<String> diagnosticAttributes = formatter.getDiagnosticAttributesFromFullDocument(fullDocument);
+				MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromFullDocument(fullDocument);
 				try (var __ = rootRef.diagnosticContext().withOnly(diagnosticAttributes)) {
 					downstream.submitReplacement(rootRef, newRoot);
 				}
@@ -235,8 +235,8 @@ final class SequoiaFormatDriver<R extends StateTreeNode> implements FormatDriver
 				if (updateDescription != null) {
 					BsonInt64 revision = formatter.getRevisionFromUpdateEvent(event);
 					if (shouldNotSkip(revision)) {
-						MapValue<String> attributes = formatter.getDiagnosticAttributesFromUpdateEvent(event);
-						try (var __ = rootRef.diagnosticContext().withOnly(attributes)) {
+						MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromUpdate(event);
+						try (var __ = rootRef.diagnosticContext().withOnly(diagnosticAttributes)) {
 							replaceUpdatedFields(updateDescription.getUpdatedFields());
 							deleteRemovedFields(updateDescription.getRemovedFields(), event.getOperationType());
 						}

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverSpecialTest.java
@@ -427,6 +427,8 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 	@ParametersByName
 	@UsesMongoService
 	void manifestVersionBump_disconnects() throws IOException, InterruptedException {
+		setLogging(ERROR, MongoDriver.class.getPackage()); // We're expecting some warnings here
+
 		Bosk<TestEntity> bosk = new Bosk<TestEntity>(
 			"bosk",
 			TestEntity.class,

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/DriverConformanceTest.java
@@ -430,7 +430,6 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 			// Note that this will run as soon as it's registered
 			if (diagnosticsAreReady.get()) {
 				assertEquals("attributeValue", bosk.diagnosticContext().getAttribute("attributeName"));
-				assertEquals(MapValue.singleton("attributeName", "attributeValue"), bosk.diagnosticContext().getAttributes());
 				diagnosticsVerified.release();
 			}
 		});

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/ReportingDriver.java
@@ -18,6 +18,9 @@ import java.util.function.Consumer;
 
 /**
  * Sends an {@link UpdateOperation} to a given listener whenever one of the update methods is called.
+ * <p>
+ * <em>Implementation note</em>: this class calls the downstream driver using {@link UpdateOperation#submitTo}
+ * so that the ordinary {@link DriverConformanceTest} suite also tests all the {@link UpdateOperation} objects.
  */
 public class ReportingDriver<R extends StateTreeNode> implements BoskDriver<R> {
 	final BoskDriver<R> downstream;
@@ -41,32 +44,37 @@ public class ReportingDriver<R extends StateTreeNode> implements BoskDriver<R> {
 
 	@Override
 	public <T> void submitReplacement(Reference<T> target, T newValue) {
-		updateListener.accept(new SubmitReplacement<>(target, newValue));
-		downstream.submitReplacement(target, newValue);
+		SubmitReplacement<T> op = new SubmitReplacement<>(target, newValue);
+		updateListener.accept(op);
+		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
-		updateListener.accept(new SubmitConditionalReplacement<>(target, newValue, precondition, requiredValue));
-		downstream.submitConditionalReplacement(target, newValue, precondition, requiredValue);
+		SubmitConditionalReplacement<T> op = new SubmitConditionalReplacement<>(target, newValue, precondition, requiredValue);
+		updateListener.accept(op);
+		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitInitialization(Reference<T> target, T newValue) {
-		updateListener.accept(new SubmitInitialization<>(target, newValue));
-		downstream.submitInitialization(target, newValue);
+		SubmitInitialization<T> op = new SubmitInitialization<>(target, newValue);
+		updateListener.accept(op);
+		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitDeletion(Reference<T> target) {
-		updateListener.accept(new SubmitDeletion<>(target));
-		downstream.submitDeletion(target);
+		SubmitDeletion<T> op = new SubmitDeletion<>(target);
+		updateListener.accept(op);
+		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
-		updateListener.accept(new SubmitConditionalDeletion<>(target, precondition, requiredValue));
-		downstream.submitConditionalDeletion(target, precondition, requiredValue);
+		SubmitConditionalDeletion<T> op = new SubmitConditionalDeletion<>(target, precondition, requiredValue);
+		updateListener.accept(op);
+		op.submitTo(downstream);
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/ReportingDriver.java
@@ -1,5 +1,6 @@
 package io.vena.bosk.drivers;
 
+import io.vena.bosk.BoskDiagnosticContext;
 import io.vena.bosk.BoskDriver;
 import io.vena.bosk.DriverFactory;
 import io.vena.bosk.Identifier;
@@ -15,6 +16,8 @@ import io.vena.bosk.exceptions.InvalidTypeException;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.function.Consumer;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Sends an {@link UpdateOperation} to a given listener whenever one of the update methods is called.
@@ -22,19 +25,15 @@ import java.util.function.Consumer;
  * <em>Implementation note</em>: this class calls the downstream driver using {@link UpdateOperation#submitTo}
  * so that the ordinary {@link DriverConformanceTest} suite also tests all the {@link UpdateOperation} objects.
  */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReportingDriver<R extends StateTreeNode> implements BoskDriver<R> {
 	final BoskDriver<R> downstream;
+	final BoskDiagnosticContext diagnosticContext;
 	final Consumer<UpdateOperation> updateListener;
 	final Runnable flushListener;
 
-	private ReportingDriver(BoskDriver<R> downstream, Consumer<UpdateOperation> updateListener, Runnable flushListener) {
-		this.downstream = downstream;
-		this.updateListener = updateListener;
-		this.flushListener = flushListener;
-	}
-
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Consumer<UpdateOperation> listener, Runnable flushListener) {
-		return (b,d) -> new ReportingDriver<>(d, listener, flushListener);
+		return (b,d) -> new ReportingDriver<>(d, b.diagnosticContext(), listener, flushListener);
 	}
 
 	@Override
@@ -44,35 +43,35 @@ public class ReportingDriver<R extends StateTreeNode> implements BoskDriver<R> {
 
 	@Override
 	public <T> void submitReplacement(Reference<T> target, T newValue) {
-		SubmitReplacement<T> op = new SubmitReplacement<>(target, newValue);
+		SubmitReplacement<T> op = new SubmitReplacement<>(target, newValue, diagnosticContext.getAttributes());
 		updateListener.accept(op);
 		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
-		SubmitConditionalReplacement<T> op = new SubmitConditionalReplacement<>(target, newValue, precondition, requiredValue);
+		SubmitConditionalReplacement<T> op = new SubmitConditionalReplacement<>(target, newValue, precondition, requiredValue, diagnosticContext.getAttributes());
 		updateListener.accept(op);
 		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitInitialization(Reference<T> target, T newValue) {
-		SubmitInitialization<T> op = new SubmitInitialization<>(target, newValue);
+		SubmitInitialization<T> op = new SubmitInitialization<>(target, newValue, diagnosticContext.getAttributes());
 		updateListener.accept(op);
 		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitDeletion(Reference<T> target) {
-		SubmitDeletion<T> op = new SubmitDeletion<>(target);
+		SubmitDeletion<T> op = new SubmitDeletion<>(target, diagnosticContext.getAttributes());
 		updateListener.accept(op);
 		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
-		SubmitConditionalDeletion<T> op = new SubmitConditionalDeletion<>(target, precondition, requiredValue);
+		SubmitConditionalDeletion<T> op = new SubmitConditionalDeletion<>(target, precondition, requiredValue, diagnosticContext.getAttributes());
 		updateListener.accept(op);
 		op.submitTo(downstream);
 	}

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalDeletion.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalDeletion.java
@@ -4,6 +4,7 @@ import io.vena.bosk.BoskDriver;
 import io.vena.bosk.Identifier;
 import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
+import java.util.Collection;
 import lombok.Value;
 
 @Value
@@ -16,6 +17,11 @@ public class SubmitConditionalDeletion<T> implements DeletionOperation<T>, Condi
 	@Override
 	public SubmitDeletion<T> unconditional() {
 		return new SubmitDeletion<>(target, diagnosticAttributes);
+	}
+
+	@Override
+	public SubmitConditionalDeletion<T> withFilteredAttributes(Collection<String> allowedNames) {
+		return new SubmitConditionalDeletion<>(target, precondition, requiredValue, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalDeletion.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalDeletion.java
@@ -2,6 +2,7 @@ package io.vena.bosk.drivers.operations;
 
 import io.vena.bosk.BoskDriver;
 import io.vena.bosk.Identifier;
+import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
 import lombok.Value;
 
@@ -10,10 +11,11 @@ public class SubmitConditionalDeletion<T> implements DeletionOperation<T>, Condi
 	Reference<T> target;
 	Reference<Identifier> precondition;
 	Identifier requiredValue;
+	MapValue<String> diagnosticAttributes;
 
 	@Override
 	public SubmitDeletion<T> unconditional() {
-		return new SubmitDeletion<>(target);
+		return new SubmitDeletion<>(target, diagnosticAttributes);
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalReplacement.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalReplacement.java
@@ -2,6 +2,7 @@ package io.vena.bosk.drivers.operations;
 
 import io.vena.bosk.BoskDriver;
 import io.vena.bosk.Identifier;
+import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
 import lombok.Value;
 
@@ -11,10 +12,11 @@ public class SubmitConditionalReplacement<T> implements ReplacementOperation<T>,
 	T newValue;
 	Reference<Identifier> precondition;
 	Identifier requiredValue;
+	MapValue<String> diagnosticAttributes;
 
 	@Override
 	public SubmitReplacement<T> unconditional() {
-		return new SubmitReplacement<>(target, newValue);
+		return new SubmitReplacement<>(target, newValue, diagnosticAttributes);
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalReplacement.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitConditionalReplacement.java
@@ -4,6 +4,7 @@ import io.vena.bosk.BoskDriver;
 import io.vena.bosk.Identifier;
 import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
+import java.util.Collection;
 import lombok.Value;
 
 @Value
@@ -17,6 +18,11 @@ public class SubmitConditionalReplacement<T> implements ReplacementOperation<T>,
 	@Override
 	public SubmitReplacement<T> unconditional() {
 		return new SubmitReplacement<>(target, newValue, diagnosticAttributes);
+	}
+
+	@Override
+	public SubmitConditionalReplacement<T> withFilteredAttributes(Collection<String> allowedNames) {
+		return new SubmitConditionalReplacement<>(target, newValue, precondition, requiredValue, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitDeletion.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitDeletion.java
@@ -1,12 +1,14 @@
 package io.vena.bosk.drivers.operations;
 
 import io.vena.bosk.BoskDriver;
+import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
 import lombok.Value;
 
 @Value
 public class SubmitDeletion<T> implements DeletionOperation<T> {
 	Reference<T> target;
+	MapValue<String> diagnosticAttributes;
 
 	@Override
 	public void submitTo(BoskDriver<?> driver) {

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitDeletion.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitDeletion.java
@@ -3,12 +3,18 @@ package io.vena.bosk.drivers.operations;
 import io.vena.bosk.BoskDriver;
 import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
+import java.util.Collection;
 import lombok.Value;
 
 @Value
 public class SubmitDeletion<T> implements DeletionOperation<T> {
 	Reference<T> target;
 	MapValue<String> diagnosticAttributes;
+
+	@Override
+	public SubmitDeletion<T> withFilteredAttributes(Collection<String> allowedNames) {
+		return new SubmitDeletion<>(target, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
+	}
 
 	@Override
 	public void submitTo(BoskDriver<?> driver) {

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitInitialization.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitInitialization.java
@@ -1,6 +1,7 @@
 package io.vena.bosk.drivers.operations;
 
 import io.vena.bosk.BoskDriver;
+import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
 import lombok.Value;
 
@@ -8,6 +9,7 @@ import lombok.Value;
 public class SubmitInitialization<T> implements ReplacementOperation<T> {
 	Reference<T> target;
 	T newValue;
+	MapValue<String> diagnosticAttributes;
 
 	@Override
 	public void submitTo(BoskDriver<?> driver) {

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitInitialization.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitInitialization.java
@@ -3,6 +3,7 @@ package io.vena.bosk.drivers.operations;
 import io.vena.bosk.BoskDriver;
 import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
+import java.util.Collection;
 import lombok.Value;
 
 @Value
@@ -10,6 +11,11 @@ public class SubmitInitialization<T> implements ReplacementOperation<T> {
 	Reference<T> target;
 	T newValue;
 	MapValue<String> diagnosticAttributes;
+
+	@Override
+	public SubmitInitialization<T> withFilteredAttributes(Collection<String> allowedNames) {
+		return new SubmitInitialization<>(target, newValue, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
+	}
 
 	@Override
 	public void submitTo(BoskDriver<?> driver) {

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitReplacement.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitReplacement.java
@@ -1,6 +1,7 @@
 package io.vena.bosk.drivers.operations;
 
 import io.vena.bosk.BoskDriver;
+import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
 import lombok.Value;
 
@@ -8,6 +9,7 @@ import lombok.Value;
 public class SubmitReplacement<T> implements ReplacementOperation<T> {
 	Reference<T> target;
 	T newValue;
+	MapValue<String> diagnosticAttributes;
 
 	@Override
 	public void submitTo(BoskDriver<?> driver) {

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitReplacement.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/SubmitReplacement.java
@@ -3,6 +3,7 @@ package io.vena.bosk.drivers.operations;
 import io.vena.bosk.BoskDriver;
 import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
+import java.util.Collection;
 import lombok.Value;
 
 @Value
@@ -10,6 +11,11 @@ public class SubmitReplacement<T> implements ReplacementOperation<T> {
 	Reference<T> target;
 	T newValue;
 	MapValue<String> diagnosticAttributes;
+
+	@Override
+	public SubmitReplacement<T> withFilteredAttributes(Collection<String> allowedNames) {
+		return new SubmitReplacement<>(target, newValue, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
+	}
 
 	@Override
 	public void submitTo(BoskDriver<?> driver) {

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/UpdateOperation.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/UpdateOperation.java
@@ -1,10 +1,22 @@
 package io.vena.bosk.drivers.operations;
 
 import io.vena.bosk.BoskDriver;
+import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
 
 public interface UpdateOperation {
 	Reference<?> target();
+	MapValue<String> diagnosticAttributes();
+
+	/**
+	 * @return true if this operation matches <code>other</code> ignoring any preconditions.
+	 */
 	boolean matchesIfApplied(UpdateOperation other);
+
+	/**
+	 * Calls the appropriate <code>submit</code> method on the given driver.
+	 * Any {@link io.vena.bosk.BoskDiagnosticContext diagnostic context} is <em>not</em> propagated;
+	 * if that behaviour is desired, the caller must do it.
+	 */
 	void submitTo(BoskDriver<?> driver);
 }

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/UpdateOperation.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/operations/UpdateOperation.java
@@ -3,6 +3,7 @@ package io.vena.bosk.drivers.operations;
 import io.vena.bosk.BoskDriver;
 import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
+import java.util.Collection;
 
 public interface UpdateOperation {
 	Reference<?> target();
@@ -13,6 +14,7 @@ public interface UpdateOperation {
 	 */
 	boolean matchesIfApplied(UpdateOperation other);
 
+	UpdateOperation withFilteredAttributes(Collection<String> allowedNames);
 	/**
 	 * Calls the appropriate <code>submit</code> method on the given driver.
 	 * Any {@link io.vena.bosk.BoskDiagnosticContext diagnostic context} is <em>not</em> propagated;

--- a/bosk-testing/src/test/java/io/vena/bosk/drivers/ReportingDriverConformanceTest.java
+++ b/bosk-testing/src/test/java/io/vena/bosk/drivers/ReportingDriverConformanceTest.java
@@ -1,0 +1,12 @@
+package io.vena.bosk.drivers;
+
+import org.junit.jupiter.api.BeforeEach;
+
+class ReportingDriverConformanceTest extends DriverConformanceTest {
+
+	@BeforeEach
+	void setupDriverFactory() {
+		driverFactory = ReportingDriver.factory(op->{}, ()->{});
+	}
+
+}

--- a/bosk-testing/src/test/java/io/vena/bosk/drivers/ReportingDriverTest.java
+++ b/bosk-testing/src/test/java/io/vena/bosk/drivers/ReportingDriverTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import lombok.var;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -142,7 +143,10 @@ class ReportingDriverTest extends AbstractDriverTest {
 		} catch (IOException | InterruptedException e) {
 			throw new NotYetImplementedException(e);
 		}
-		assertEquals(asList(expectedOps), this.ops);
+		List<UpdateOperation> actual = ops.stream()
+			.map(op -> op.withFilteredAttributes(expectedAttributes.keySet())) // Unexpected attributes are not grounds for failing the test
+			.collect(Collectors.toList());
+		assertEquals(asList(expectedOps), actual);
 	}
 
 	private <T> void assertNodeEquals(T expectedValue, Reference<T> location) {

--- a/bosk-testing/src/test/java/io/vena/bosk/drivers/ReportingDriverTest.java
+++ b/bosk-testing/src/test/java/io/vena/bosk/drivers/ReportingDriverTest.java
@@ -1,7 +1,9 @@
 package io.vena.bosk.drivers;
 
+import io.vena.bosk.BoskDiagnosticContext;
 import io.vena.bosk.Identifier;
 import io.vena.bosk.ListingEntry;
+import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
 import io.vena.bosk.annotations.ReferencePath;
 import io.vena.bosk.drivers.operations.SubmitConditionalDeletion;
@@ -18,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.var;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +32,8 @@ class ReportingDriverTest extends AbstractDriverTest {
 	List<UpdateOperation> ops;
 	AtomicInteger numFlushes;
 	Refs refs;
+	BoskDiagnosticContext.DiagnosticScope diagnosticScope;
+	MapValue<String> expectedAttributes;
 	final Identifier id1 = Identifier.from("id1");
 	final Identifier id2 = Identifier.from("id2");
 
@@ -47,6 +52,14 @@ class ReportingDriverTest extends AbstractDriverTest {
 		refs = bosk.buildReferences(Refs.class);
 		bosk.driver().submitReplacement(refs.entity(id1), emptyEntityAt(refs.entity(id1)));
 		ops.clear();
+		diagnosticScope = bosk.diagnosticContext().withAttribute(ReportingDriverTest.class.getSimpleName(), "expectedValue");
+		expectedAttributes = bosk.diagnosticContext().getAttributes();
+	}
+
+	@AfterEach
+	void closeDiagnosticScope() {
+		diagnosticScope.close();
+		diagnosticScope = null;
 	}
 
 	@Test
@@ -60,7 +73,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 		Reference<String> ref = refs.string(id1);
 		String newValue = "submitReplacement";
 		bosk.driver().submitReplacement(ref, newValue);
-		assertExpectedEvents(new SubmitReplacement<>(ref, newValue));
+		assertExpectedEvents(new SubmitReplacement<>(ref, newValue, expectedAttributes));
 		assertNodeEquals(newValue, ref);
 		assertCorrectBoskContents();
 	}
@@ -72,7 +85,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 		Reference<Identifier> precondition = refs.id();
 		Identifier requiredValue = Identifier.from("root");
 		bosk.driver().submitConditionalReplacement(ref, newValue, precondition, requiredValue);
-		assertExpectedEvents(new SubmitConditionalReplacement<>(ref, newValue, precondition, requiredValue));
+		assertExpectedEvents(new SubmitConditionalReplacement<>(ref, newValue, precondition, requiredValue, expectedAttributes));
 		assertNodeEquals(newValue, ref);
 		assertCorrectBoskContents();
 	}
@@ -82,7 +95,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 		Reference<TestEntity> ref = refs.entity(id2);
 		TestEntity newValue = emptyEntityAt(ref);
 		bosk.driver().submitInitialization(ref, newValue);
-		assertExpectedEvents(new SubmitInitialization<>(ref, newValue));
+		assertExpectedEvents(new SubmitInitialization<>(ref, newValue, expectedAttributes));
 		assertNodeEquals(newValue, ref);
 		assertCorrectBoskContents();
 	}
@@ -91,13 +104,13 @@ class ReportingDriverTest extends AbstractDriverTest {
 	void submitDeletion() {
 		Reference<ListingEntry> ref = refs.entry(id1);
 		bosk.driver().submitReplacement(ref, LISTING_ENTRY);
-		assertExpectedEvents(new SubmitReplacement<>(ref, LISTING_ENTRY));
+		assertExpectedEvents(new SubmitReplacement<>(ref, LISTING_ENTRY, expectedAttributes));
 		assertNodeEquals(LISTING_ENTRY, ref);
 		assertCorrectBoskContents();
 
 		ops.clear();
 		bosk.driver().submitDeletion(ref);
-		assertExpectedEvents(new SubmitDeletion<>(ref));
+		assertExpectedEvents(new SubmitDeletion<>(ref, expectedAttributes));
 		assertNodeEquals(null, ref);
 		assertCorrectBoskContents();
 	}
@@ -106,7 +119,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 	void submitConditionalDeletion() {
 		Reference<ListingEntry> ref = refs.entry(id1);
 		bosk.driver().submitReplacement(ref, LISTING_ENTRY);
-		assertExpectedEvents(new SubmitReplacement<>(ref, LISTING_ENTRY));
+		assertExpectedEvents(new SubmitReplacement<>(ref, LISTING_ENTRY, expectedAttributes));
 		assertNodeEquals(LISTING_ENTRY, ref);
 		assertCorrectBoskContents();
 
@@ -114,7 +127,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 		Reference<Identifier> precondition = refs.id();
 		Identifier requiredValue = Identifier.from("root");
 		bosk.driver().submitConditionalDeletion(ref, precondition, requiredValue);
-		assertExpectedEvents(new SubmitConditionalDeletion<>(ref, precondition, requiredValue));
+		assertExpectedEvents(new SubmitConditionalDeletion<>(ref, precondition, requiredValue, expectedAttributes));
 		assertNodeEquals(null, ref);
 		assertCorrectBoskContents();
 	}


### PR DESCRIPTION
Beef up propagation of diagnostic attributes, and then use one to pass the thread ID in `DriverStateVerifier` so it doesn't need to guess at how to demultiplex them.