### PR TITLE
Polyfill for deserialization

### DIFF
--- a/bosk-core/src/main/java/io/vena/bosk/SerializationPlugin.java
+++ b/bosk-core/src/main/java/io/vena/bosk/SerializationPlugin.java
@@ -295,7 +295,7 @@ public abstract class SerializationPlugin {
 		// like Lombok or Java 14's Records that derive constructors from fields.
 
 		for (Class<?> c = nodeClassArg; c != Object.class; c = c.getSuperclass()) {
-			for (Field field: nodeClassArg.getDeclaredFields()) {
+			for (Field field: c.getDeclaredFields()) {
 				scanForInfo(field, field.getName(),
 					selfParameters, enclosingParameters, deserializationPathParameters);
 			}

--- a/bosk-core/src/main/java/io/vena/bosk/SerializationPlugin.java
+++ b/bosk-core/src/main/java/io/vena/bosk/SerializationPlugin.java
@@ -2,6 +2,7 @@ package io.vena.bosk;
 
 import io.vena.bosk.annotations.DeserializationPath;
 import io.vena.bosk.annotations.Enclosing;
+import io.vena.bosk.annotations.Polyfill;
 import io.vena.bosk.annotations.Self;
 import io.vena.bosk.exceptions.DeserializationException;
 import io.vena.bosk.exceptions.InvalidTypeException;
@@ -27,6 +28,8 @@ import lombok.Value;
 import static io.vena.bosk.ReferenceUtils.parameterType;
 import static io.vena.bosk.ReferenceUtils.rawClass;
 import static io.vena.bosk.ReferenceUtils.theOnlyConstructorFor;
+import static java.lang.reflect.Modifier.isPrivate;
+import static java.lang.reflect.Modifier.isStatic;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -192,6 +195,7 @@ public abstract class SerializationPlugin {
 				} else if (Phantom.class.equals(type)) {
 					parameterValues.add(Phantom.empty());
 				} else {
+					Object polyfillIfAny = infoFor(nodeClass).polyfills().get(name);
 					Path path = currentScope.get().path();
 					if ("id".equals(name) && !path.isEmpty()) {
 						// If the object is an entry in a Catalog or a key in a SideTable, we can determine its ID
@@ -206,6 +210,8 @@ public abstract class SerializationPlugin {
 						} else {
 							throw new DeserializationException("Missing id field for object at " + path);
 						}
+					} else if (polyfillIfAny != null) {
+						parameterValues.add(polyfillIfAny);
 					} else {
 						throw new DeserializationException("Missing field \"" + name + "\" at " + path);
 					}
@@ -283,41 +289,68 @@ public abstract class SerializationPlugin {
 		Set<String> selfParameters = new HashSet<>();
 		Set<String> enclosingParameters = new HashSet<>();
 		Map<String, DeserializationPath> deserializationPathParameters = new HashMap<>();
+		Map<String, Object> polyfills = new HashMap<>();
 		for (Parameter parameter: theOnlyConstructorFor(nodeClassArg).getParameters()) {
 			scanForInfo(parameter, parameter.getName(),
-				selfParameters, enclosingParameters, deserializationPathParameters);
+				selfParameters, enclosingParameters, deserializationPathParameters, polyfills);
 		}
 
 		// Bosk generally ignores an object's fields, looking only at its
 		// constructor arguments and its getters. However, we make an exception
 		// for convenience: Bosk annotations that go on constructor parameters
 		// can also go on fields with the same name. This accommodates systems
-		// like Lombok or Java 14's Records that derive constructors from fields.
+		// like Lombok that derive constructors from fields.
 
 		for (Class<?> c = nodeClassArg; c != Object.class; c = c.getSuperclass()) {
 			for (Field field: c.getDeclaredFields()) {
 				scanForInfo(field, field.getName(),
-					selfParameters, enclosingParameters, deserializationPathParameters);
+					selfParameters, enclosingParameters, deserializationPathParameters, polyfills);
 			}
 		}
-		return new ParameterInfo(selfParameters, enclosingParameters, deserializationPathParameters);
+		return new ParameterInfo(selfParameters, enclosingParameters, deserializationPathParameters, polyfills);
 	}
 
-	private static void scanForInfo(AnnotatedElement thing, String name, Set<String> selfParameters, Set<String> enclosingParameters, Map<String, DeserializationPath> deserializationPathParameters) {
+	private static void scanForInfo(AnnotatedElement thing, String name, Set<String> selfParameters, Set<String> enclosingParameters, Map<String, DeserializationPath> deserializationPathParameters, Map<String, Object> polyfills) {
 		if (thing.isAnnotationPresent(Self.class)) {
 			selfParameters.add(name);
 		} else if (thing.isAnnotationPresent(Enclosing.class)) {
 			enclosingParameters.add(name);
 		} else if (thing.isAnnotationPresent(DeserializationPath.class)) {
 			deserializationPathParameters.put(name, thing.getAnnotation(DeserializationPath.class));
+		} else if (thing.isAnnotationPresent(Polyfill.class)) {
+			if (thing instanceof Field f && isStatic(f.getModifiers()) && !isPrivate(f.getModifiers())) {
+				f.setAccessible(true);
+				for (Polyfill polyfill : thing.getAnnotationsByType(Polyfill.class)) {
+					Object value;
+					try {
+						value = f.get(null);
+					} catch (IllegalAccessException e) {
+						throw new AssertionError("Field should not be inaccessible: " + f, e);
+					}
+					if (value == null) {
+						throw new NullPointerException("Polyfill value cannot be null: " + f);
+					}
+					for (String fieldName: polyfill.value()) {
+						Object previous = polyfills.put(fieldName, value);
+						if (previous != null) {
+							throw new IllegalStateException("Multiple polyfills for the same field \"" + fieldName + "\": " + f);
+						}
+					}
+					// TODO: Polyfills can't be used for implicit refs, Optionals, Phantoms
+					// Also can't be used for Entity.id
+				}
+			} else {
+				throw new IllegalStateException("@Polyfill annotation is only valid on non-private static fields; found on " + thing);
+			}
 		}
 	}
 
 	private record ParameterInfo(
-		Set<String> annotatedParameters_Self, Set<String> annotatedParameters_Enclosing,
-		Map<String, DeserializationPath> annotatedParameters_DeserializationPath
-	) {
-	}
+		Set<String> annotatedParameters_Self,
+		Set<String> annotatedParameters_Enclosing,
+		Map<String, DeserializationPath> annotatedParameters_DeserializationPath,
+		Map<String, Object> polyfills
+	) { }
 
 	private static final Map<Class<?>, ParameterInfo> PARAMETER_INFO_MAP = new ConcurrentHashMap<>();
 

--- a/bosk-core/src/main/java/io/vena/bosk/annotations/Polyfill.java
+++ b/bosk-core/src/main/java/io/vena/bosk/annotations/Polyfill.java
@@ -1,0 +1,32 @@
+package io.vena.bosk.annotations;
+
+import io.vena.bosk.StateTreeNode;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Optional;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks a static final field in a {@link StateTreeNode} to indicate that it can be
+ * used as a default value for a given field, for backward compatibility with external
+ * systems that don't yet support the field.
+ *
+ * <p>
+ * This is not meant to be used just to supply default values for optional fields;
+ * that should be achieved by declaring the field {@link Optional}
+ * and calling {@link Optional#orElse} when the field is used.
+ * Rather, this is meant to be used <em>temporarily</em> with newly added fields
+ * to support systems that are not yet aware of those fields.
+ *
+ * @author Patrick Doyle
+ */
+@Retention(RUNTIME)
+@Target({ FIELD })
+public @interface Polyfill {
+	/**
+	 * The names of the fields for which we're supplying a default value.
+	 */
+	String[] value();
+}

--- a/bosk-core/src/test/java/io/vena/bosk/SerializationPluginTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/SerializationPluginTest.java
@@ -1,0 +1,35 @@
+package io.vena.bosk;
+
+import io.vena.bosk.annotations.Self;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import static io.vena.bosk.ReferenceUtils.theOnlyConstructorFor;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// TODO: This should aim for full coverage of SerializationPlugin
+class SerializationPluginTest {
+
+	@Test
+	void inheritedFieldAttribute_works() {
+		Constructor<Child> childConstructor = theOnlyConstructorFor(Child.class);
+		Parameter selfParameter = childConstructor.getParameters()[0];
+		assertTrue(SerializationPlugin.isSelfReference(Child.class, selfParameter));
+	}
+
+	@RequiredArgsConstructor
+	@Getter
+	static class Parent {
+		@Self final Parent self;
+	}
+
+	@Getter
+	static class Child extends Parent {
+		public Child(Parent self) {
+			super(self);
+		}
+	}
+}

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/AbstractMongoDriverTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/AbstractMongoDriverTest.java
@@ -154,17 +154,10 @@ abstract class AbstractMongoDriverTest {
 	}
 
 	public interface Refs {
-		@ReferencePath("/catalog")
-		CatalogReference<TestEntity> catalog();
-
-		@ReferencePath("/listing")
-		ListingReference<TestEntity> listing();
-
-		@ReferencePath("/listing/-entity-")
-		Reference<ListingEntry> listingEntry(Identifier entity);
-
-		@ReferencePath("/catalog/-child-/catalog")
-		CatalogReference<TestEntity> childCatalog(Identifier child);
+		@ReferencePath("/catalog") CatalogReference<TestEntity> catalog();
+		@ReferencePath("/listing") ListingReference<TestEntity> listing();
+		@ReferencePath("/listing/-entity-") Reference<ListingEntry> listingEntry(Identifier entity);
+		@ReferencePath("/catalog/-child-/catalog") CatalogReference<TestEntity> childCatalog(Identifier child);
 	}
 
 	private static final AtomicBoolean ALREADY_WARNED = new AtomicBoolean(false);

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/BsonPluginTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/BsonPluginTest.java
@@ -1,7 +1,6 @@
 package io.vena.bosk.drivers.mongo;
 
 import io.vena.bosk.Bosk;
-import io.vena.bosk.Bosk.ReadContext;
 import io.vena.bosk.Catalog;
 import io.vena.bosk.CatalogReference;
 import io.vena.bosk.Entity;
@@ -10,8 +9,6 @@ import io.vena.bosk.Path;
 import io.vena.bosk.SideTable;
 import io.vena.bosk.StateTreeNode;
 import io.vena.bosk.exceptions.InvalidTypeException;
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import lombok.experimental.FieldNameConstants;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentReader;
@@ -34,7 +31,7 @@ class BsonPluginTest {
 		Bosk<Root> bosk = new Bosk<Root>("Test bosk", Root.class, this::defaultRoot, Bosk::simpleDriver);
 		CodecRegistry registry = CodecRegistries.fromProviders(bp.codecProviderFor(bosk), new ValueCodecProvider());
 		Codec<Root> codec = registry.get(Root.class);
-		try (ReadContext context = bosk.readContext()) {
+		try (var __ = bosk.readContext()) {
 			BsonDocument document = new BsonDocument();
 			Root original = bosk.rootReference().value();
 			codec.encode(new BsonDocumentWriter(document), original, EncoderContext.builder().build());
@@ -48,17 +45,14 @@ class BsonPluginTest {
 		return new Root(Catalog.empty(), SideTable.empty(catalogRef));
 	}
 
-	@Value @FieldNameConstants
-	@EqualsAndHashCode(callSuper = false)
-	public static class Root implements StateTreeNode {
-		Catalog<Item> items;
-		SideTable<Item, SideTable<Item, String>> nestedSideTable;
-	}
+	@FieldNameConstants
+	public record Root(
+		Catalog<Item> items,
+		SideTable<Item, SideTable<Item, String>> nestedSideTable
+	) implements StateTreeNode { }
 
-	@Value @FieldNameConstants
-	@EqualsAndHashCode(callSuper = false)
-	public static class Item implements Entity {
-		Identifier id;
-	}
+	public record Item(
+		Identifier id
+	) implements Entity { }
 
 }

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverSpecialTest.java
@@ -90,7 +90,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			throw new AssertionError("Default root function should not be called");
 		}, driverFactory);
 
-		try (@SuppressWarnings("unused") Bosk<TestEntity>.ReadContext context = latecomerBosk.readContext()) {
+		try (var __ = latecomerBosk.readContext()) {
 			TestEntity actual = latecomerBosk.rootReference().value();
 			assertEquals(expected, actual);
 		}
@@ -135,7 +135,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			}
 		}
 
-		try (@SuppressWarnings("unused") Bosk<TestEntity>.ReadContext context = bosk.readContext()) {
+		try (var __ = bosk.readContext()) {
 			TestEntity expected = initialRoot(bosk);
 			TestEntity actual = bosk.rootReference().value();
 			assertEquals(expected, actual, "MongoDriver should not have called downstream.flush() yet");
@@ -143,7 +143,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 
 		bosk.driver().flush();
 
-		try (@SuppressWarnings("unused") Bosk<TestEntity>.ReadContext context = bosk.readContext()) {
+		try (var __ = bosk.readContext()) {
 			TestEntity expected = initialRoot(bosk).withListing(Listing.of(catalogRef, entity123));
 			TestEntity actual = bosk.rootReference().value();
 			assertEquals(expected, actual, "MongoDriver.flush() should reliably update the bosk");
@@ -171,7 +171,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 
 		// Check the contents
 		driver.flush();
-		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = bosk.readContext()) {
+		try (var __ = bosk.readContext()) {
 			Listing<TestEntity> actual = listingRef.value();
 			Listing<TestEntity> expected = Listing.of(catalogRef, entity124, entity123);
 			assertEquals(expected, actual);
@@ -182,7 +182,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 
 		// Check the contents
 		driver.flush();
-		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = bosk.readContext()) {
+		try (var __ = bosk.readContext()) {
 			Listing<TestEntity> actual = listingRef.value();
 			Listing<TestEntity> expected = Listing.of(catalogRef, entity124);
 			assertEquals(expected, actual);
@@ -221,14 +221,14 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 
 		driver.flush();
 		TestEntity actual;
-		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = bosk.readContext()) {
+		try (var __ = bosk.readContext()) {
 			actual = bosk.rootReference().value();
 		}
 		assertEquals(expected, actual);
 
 		latecomerBosk.driver().flush();
 		TestEntity latecomerActual;
-		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = latecomerBosk.readContext()) {
+		try (var __ = latecomerBosk.readContext()) {
 			latecomerActual = latecomerBosk.rootReference().value();
 		}
 		assertEquals(expected, latecomerActual);
@@ -279,7 +279,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			.withListing(Listing.of(refs.catalog(), entity123, entity124));
 
 		TestEntity actual;
-		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = bosk.readContext()) {
+		try (var __ = bosk.readContext()) {
 			actual = bosk.rootReference().value();
 		}
 		assertEquals(expected, actual);
@@ -301,7 +301,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		OldEntity expected = OldEntity.withString(rootID.toString(), prevBosk);
 
 		OldEntity actual;
-		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = prevBosk.readContext()) {
+		try (var __ = prevBosk.readContext()) {
 			actual = prevBosk.rootReference().value();
 		}
 		assertEquals(expected, actual);
@@ -328,7 +328,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		OldEntity expected = OldEntity.withString("replacementString", prevBosk);
 
 		OldEntity actual;
-		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = prevBosk.readContext()) {
+		try (var __ = prevBosk.readContext()) {
 			actual = prevBosk.rootReference().value();
 		}
 
@@ -356,7 +356,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		OldEntity expected = OldEntity.withString(rootID.toString(), prevBosk); // unchanged
 
 		OldEntity actual;
-		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = prevBosk.readContext()) {
+		try (var __ = prevBosk.readContext()) {
 			actual = prevBosk.rootReference().value();
 		}
 
@@ -382,7 +382,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		OldEntity expected = OldEntity.withString(rootID.toString(), prevBosk); // unchanged
 
 		OldEntity actual;
-		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = prevBosk.readContext()) {
+		try (var __ = prevBosk.readContext()) {
 			actual = prevBosk.rootReference().value();
 		}
 
@@ -457,7 +457,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 
 		LOGGER.debug("Check state before");
 		Optional<TestValues> before;
-		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = originalBosk.readContext()) {
+		try (var __ = originalBosk.readContext()) {
 			before = originalBosk.rootReference().value().values();
 		}
 		assertEquals(Optional.empty(), before); // Not there yet
@@ -468,7 +468,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 
 		LOGGER.debug("Check state after");
 		Optional<TestValues> after;
-		try (@SuppressWarnings("unused") Bosk<?>.ReadContext readContext = originalBosk.readContext()) {
+		try (var __ = originalBosk.readContext()) {
 			after = originalBosk.rootReference().value().values();
 		}
 		assertEquals(Optional.of(TestValues.blank()), after); // Now it's there


### PR DESCRIPTION
Adds a `@Polyfill` annotation that simplifies rollout of new fields by injecting a default value in `SerializationPlugin` if the field is missing.