### PR TITLE
Fix disconnected events

### DIFF
--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/DisconnectedDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/DisconnectedDriver.java
@@ -51,8 +51,8 @@ class DisconnectedDriver<R extends StateTreeNode> implements FormatDriver<R> {
 	}
 
 	@Override
-	public void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
-		throw new UnprocessableEventException("Cannot process event when disconnected", event.getOperationType());
+	public void onEvent(ChangeStreamDocument<BsonDocument> event) {
+		throw disconnected();
 	}
 
 	@Override

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/DisconnectedDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/DisconnectedDriver.java
@@ -51,8 +51,8 @@ class DisconnectedDriver<R extends StateTreeNode> implements FormatDriver<R> {
 	}
 
 	@Override
-	public void onEvent(ChangeStreamDocument<BsonDocument> event) {
-		LOGGER.debug("Already disconnected; ignoring event ({})", event.getOperationType().getValue());
+	public void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
+		throw new UnprocessableEventException("Cannot process event when disconnected", event.getOperationType());
 	}
 
 	@Override

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
@@ -539,6 +539,8 @@ class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 			} catch (DisconnectedException e) {
 				LOGGER.debug("Driver is disconnected ({}); will wait and retry operation", e.getMessage());
 				waitAndRetry(operationInSession, description, args);
+			} finally {
+				LOGGER.debug("Finished operation " + description, args);
 			}
 		}
 	}

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/AbstractMongoDriverTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/AbstractMongoDriverTest.java
@@ -16,6 +16,7 @@ import io.vena.bosk.SideTable;
 import io.vena.bosk.annotations.ReferencePath;
 import io.vena.bosk.drivers.mongo.MongoDriverSettings.MongoDriverSettingsBuilder;
 import io.vena.bosk.drivers.state.TestEntity;
+import io.vena.bosk.drivers.state.TestValues;
 import io.vena.bosk.exceptions.InvalidTypeException;
 import java.lang.reflect.Method;
 import java.util.ArrayDeque;
@@ -124,6 +125,11 @@ abstract class AbstractMongoDriverTest {
 			));
 	}
 
+	public TestEntity initialRootWithValues(Bosk<TestEntity> testEntityBosk) throws InvalidTypeException {
+		return initialRootWithEmptyCatalog(testEntityBosk)
+			.withValues(Optional.of(TestValues.blank()));
+	}
+
 	public TestEntity initialRootWithEmptyCatalog(Bosk<TestEntity> testEntityBosk) throws InvalidTypeException {
 		Refs refs = testEntityBosk.buildReferences(Refs.class);
 		return new TestEntity(rootID,
@@ -160,6 +166,7 @@ abstract class AbstractMongoDriverTest {
 		@ReferencePath("/catalog/-child-/catalog") CatalogReference<TestEntity> childCatalog(Identifier child);
 		@ReferencePath("/listing") ListingReference<TestEntity> listing();
 		@ReferencePath("/listing/-entity-") Reference<ListingEntry> listingEntry(Identifier entity);
+		@ReferencePath("/values") Reference<TestValues> values();
 		@ReferencePath("/values/string") Reference<String> valuesString();
 	}
 


### PR DESCRIPTION
`DisconnectedDriver` was ignoring events. Made sense, I guess: it's disconnected, after all. But this meant that liveness was lost, and a subsequent `flush()` might not notice that the database got repaired.

The fix: `ChangeReceiver` now responds to `DisconnectedException` by exiting the event loop, which causes it to wait and retry. (If we don't wait, we risk getting into a tight loop reinitializing the driver on every received change event, which could burn CPU or IO. Given that this is an exception recovery scenario, better to wait a few seconds and take it easy.)