### PR TITLE
Logging MDC tweaks

### DIFF
--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
@@ -81,7 +81,7 @@ class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 		BsonPlugin bsonPlugin,
 		BoskDriver<R> downstream
 	) {
-		try (MDCScope __ = setupMDC(bosk.name())) {
+		try (MDCScope __ = setupMDC(bosk.name(), bosk.instanceID())) {
 			this.bosk = bosk;
 			this.driverSettings = driverSettings;
 			this.bsonPlugin = bsonPlugin;
@@ -102,7 +102,7 @@ class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 			Type rootType = bosk.rootReference().targetType();
 			this.listener = new Listener(new FutureTask<>(() -> doInitialRoot(rootType)));
 			this.formatter = new Formatter(bosk, bsonPlugin);
-			this.receiver = new ChangeReceiver(bosk.name(), listener, driverSettings, rawCollection);
+			this.receiver = new ChangeReceiver(bosk.name(), bosk.instanceID(), listener, driverSettings, rawCollection);
 		}
 	}
 
@@ -510,7 +510,7 @@ class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 		if (isClosed) {
 			throw new IllegalStateException("Driver is closed");
 		}
-		MDCScope ex = setupMDC(bosk.name());
+		MDCScope ex = setupMDC(bosk.name(), bosk.instanceID());
 		LOGGER.debug(description, args);
 		if (driverSettings.testing().eventDelayMS() < 0) {
 			LOGGER.debug("| eventDelayMS {}ms ", driverSettings.testing().eventDelayMS());

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MappedDiagnosticContext.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MappedDiagnosticContext.java
@@ -1,11 +1,17 @@
 package io.vena.bosk.drivers.mongo;
 
+import io.vena.bosk.Identifier;
 import org.slf4j.MDC;
 
+import static io.vena.bosk.drivers.mongo.MdcKeys.BOSK_INSTANCE_ID;
+import static io.vena.bosk.drivers.mongo.MdcKeys.BOSK_NAME;
+
 final class MappedDiagnosticContext {
-	static MDCScope setupMDC(String boskName) {
+
+	static MDCScope setupMDC(String boskName, Identifier boskID) {
 		MDCScope result = new MDCScope();
-		MDC.put(MDC_KEY, " [" + boskName + "]");
+		MDC.put(BOSK_NAME, boskName);
+		MDC.put(BOSK_INSTANCE_ID, boskID.toString());
 		return result;
 	}
 
@@ -22,9 +28,12 @@ final class MappedDiagnosticContext {
 	 * You really want to use this in a try block that has no catch or finally clause.
 	 */
 	static final class MDCScope implements AutoCloseable {
-		final String oldValue = MDC.get(MDC_KEY);
-		@Override public void close() { MDC.put(MDC_KEY, oldValue); }
+		final String oldName = MDC.get(BOSK_NAME);
+		final String oldID = MDC.get(BOSK_INSTANCE_ID);
+		@Override public void close() {
+			MDC.put(BOSK_NAME, oldName);
+			MDC.put(BOSK_INSTANCE_ID, oldID);
+		}
 	}
 
-	private static final String MDC_KEY = "bosk.MongoDriver";
 }

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MdcKeys.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MdcKeys.java
@@ -1,0 +1,12 @@
+package io.vena.bosk.drivers.mongo;
+
+/**
+ * Evolution note: we're going to want to get organized in how we generate MDC.
+ * For now, it's all in bosk-mongo, so we can put these keys here.
+ */
+final class MdcKeys {
+	static final String BOSK_NAME        = "bosk.name";
+	static final String BOSK_INSTANCE_ID = "bosk.instanceID";
+	static final String EVENT            = "bosk.MongoDriver.event";
+	static final String TRANSACTION      = "bosk.MongoDriver.transaction";
+}

--- a/lib-testing/src/main/resources/logback.xml
+++ b/lib-testing/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%d %-5level [%thread]%X{MongoDriver}%X{MongoDriver.transaction}%X{MongoDriver.event} %logger{25}: %msg%n</pattern>
+			<pattern>%d %-5level [%thread] [%X{bosk.name}]%X{bosk.MongoDriver.transaction}%X{bosk.MongoDriver.event} %logger{25}: %msg%n</pattern>
 		</encoder>
 		<immediateFlush>true</immediateFlush>
 	</appender>


### PR DESCRIPTION
Our current mapped diagnostic context (MDC) is a bit nonsensical.

- Put it all under a `bosk` prefix
- Report the bosk name and instance ID
  - The instance ID could be particularly useful for tying together events that happened to the same bosk