### PR TITLE
Revision backdating

### DIFF
--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
@@ -639,6 +639,6 @@ class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 
 	public static final String COLLECTION_NAME = "boskCollection";
 	public static final BsonString MANIFEST_ID = new BsonString("manifest");
-	private static final Exception FAILURE_TO_COMPUTE_INITIAL_ROOT = new Exception("Failure to compute initial root");
+	private static final Exception FAILURE_TO_COMPUTE_INITIAL_ROOT = new InitialRootFailureException("Failure to compute initial root");
 	private static final Logger LOGGER = LoggerFactory.getLogger(MainDriver.class);
 }

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/UnprocessableEventException.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/UnprocessableEventException.java
@@ -14,7 +14,7 @@ class UnprocessableEventException extends Exception {
 	public final OperationType operationType;
 
 	public UnprocessableEventException(String message, OperationType operationType) {
-		super(message + " (" + operationType + ")");
+		super(message + ": " + operationType.name());
 		this.operationType = operationType;
 	}
 


### PR DESCRIPTION
Fixes #95.

When loading the state from the database, initializes the `FlushLock` to _one less_ than the current revision number, until after the state is submitted downstream, and _then_ marks it safe to skip. This way, in the window between when the `FlushLock` is created and the state is submitted downstream, any `flush` operations called by other threads will wait.

Sounds a bit sketchy, but I think it's sound.