### PR TITLE
`MongoStatus` feature

### DIFF
--- a/bosk-core/src/test/java/io/vena/bosk/IdentifierTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/IdentifierTest.java
@@ -3,7 +3,8 @@ package io.vena.bosk;
 import io.vena.bosk.junit.ParametersByName;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class IdentifierTest {
 

--- a/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/io/vena/bosk/jackson/JacksonPlugin.java
@@ -55,7 +55,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import lombok.Value;
 
 import static com.fasterxml.jackson.core.JsonToken.END_ARRAY;
 import static com.fasterxml.jackson.core.JsonToken.END_OBJECT;

--- a/bosk-mongo/build.gradle
+++ b/bosk-mongo/build.gradle
@@ -18,6 +18,10 @@ java {
 dependencies {
 	api project(":bosk-core")
 	api 'org.mongodb:mongodb-driver-sync:4.1.2'
+
+	// Allows us to annotate status objects so they're handy to serialize with jackson
+	implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.16.1'
+
 	testImplementation project(":bosk-testing")
 	testImplementation project(":lib-testing")
 }

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/AbstractFormatDriver.java
@@ -3,6 +3,7 @@ package io.vena.bosk.drivers.mongo;
 import io.vena.bosk.MapValue;
 import io.vena.bosk.RootReference;
 import io.vena.bosk.StateTreeNode;
+import io.vena.bosk.drivers.mongo.status.MongoStatus;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.bson.BsonDocument;
@@ -14,6 +15,24 @@ import static io.vena.bosk.drivers.mongo.Formatter.REVISION_ZERO;
 abstract class AbstractFormatDriver<R extends StateTreeNode> implements FormatDriver<R> {
 	final RootReference<R> rootRef;
 	final Formatter formatter;
+
+	@Override
+	public MongoStatus readStatus() {
+		try {
+			BsonState bsonState = loadBsonState();
+			return new MongoStatus(
+				null,
+				null, // MainDriver should fill this in
+				formatter.bsonValueBinarySize(bsonState.state)
+			);
+		} catch (UninitializedCollectionException e) {
+			return new MongoStatus(
+				e.toString(),
+				null,
+				null
+			);
+		}
+	}
 
 	@Override
 	public StateAndMetadata<R> loadAllState() throws IOException, UninitializedCollectionException {

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/ChangeReceiver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/ChangeReceiver.java
@@ -4,7 +4,6 @@ import com.mongodb.MongoInterruptedException;
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
-import io.vena.bosk.Bosk;
 import io.vena.bosk.Identifier;
 import io.vena.bosk.drivers.mongo.MappedDiagnosticContext.MDCScope;
 import java.io.Closeable;

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Demultiplexer.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Demultiplexer.java
@@ -5,10 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.Value;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
-import org.bson.Document;
 
 import static java.util.Objects.requireNonNull;
 

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/DisconnectedDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/DisconnectedDriver.java
@@ -4,6 +4,7 @@ import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import io.vena.bosk.Identifier;
 import io.vena.bosk.Reference;
 import io.vena.bosk.StateTreeNode;
+import io.vena.bosk.drivers.mongo.status.MongoStatus;
 import io.vena.bosk.exceptions.InitializationFailureException;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +44,15 @@ class DisconnectedDriver<R extends StateTreeNode> implements FormatDriver<R> {
 	@Override
 	public void flush() throws IOException, InterruptedException {
 		throw disconnected();
+	}
+
+	@Override
+	public MongoStatus readStatus() {
+		return new MongoStatus(
+			"Disconnected: " + reason,
+			null,
+			null
+		);
 	}
 
 	@Override

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/FlushLock.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/FlushLock.java
@@ -6,7 +6,6 @@ import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import lombok.Value;
 import org.bson.BsonInt64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Formatter.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Formatter.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 import lombok.NonNull;
+import org.bson.BsonBinaryWriter;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentReader;
 import org.bson.BsonDocumentWriter;
@@ -33,6 +34,7 @@ import org.bson.BsonInt64;
 import org.bson.BsonReader;
 import org.bson.BsonString;
 import org.bson.BsonValue;
+import org.bson.codecs.BsonValueCodec;
 import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.DocumentCodecProvider;
@@ -40,6 +42,7 @@ import org.bson.codecs.EncoderContext;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.io.BasicOutputBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -233,6 +236,18 @@ final class Formatter {
 			reader.readStartDocument();
 			reader.readName("value");
 			return objectCodec.decode(reader, DecoderContext.builder().build());
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	long bsonValueBinarySize(BsonValue bson) {
+		Codec<BsonValue> codec = new BsonValueCodec();
+		try (
+			BasicOutputBuffer buffer = new BasicOutputBuffer();
+			BsonBinaryWriter w = new BsonBinaryWriter(buffer)
+		) {
+			codec.encode(w, bson, EncoderContext.builder().build());
+			return buffer.getPosition();
 		}
 	}
 

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
@@ -183,7 +183,9 @@ class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 			publishFormatDriver(detectedDriver);
 			detectedDriver.onRevisionToSkip(loadedState.revision());
 		} catch (UninitializedCollectionException e) {
-			LOGGER.debug("Database collection is uninitialized; will initialize using downstream.initialRoot");
+			// We log this at warn because, in production, this is a big deal.
+			// Might be annoying in local dev ¯\_(ツ)_/¯
+			LOGGER.warn("Database collection is uninitialized; initializing now. (" + e.getMessage() + ")");
 			root = callDownstreamInitialRoot(rootType);
 			try (var session = collection.newSession()) {
 				FormatDriver<R> preferredDriver = newPreferredFormatDriver();
@@ -498,9 +500,9 @@ class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 				// One day when we drop support for collections with no
 				// manifest, we can eliminate this confusion.
 				throw new UninitializedCollectionException("Document doesn't exist: "
-					+ driverSettings.database()
+					+ "collection=" + driverSettings.database()
 					+ "." + COLLECTION_NAME
-					+ " id=" + documentId);
+					+ " id=" + documentId.getValue());
 			}
 		}
 	}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MainDriver.java
@@ -335,16 +335,13 @@ class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 
 	@Override
 	public MongoStatus readStatus() throws Exception {
-		try (var __ = collection.newReadOnlySession()) {
-			FormatDriver<R> detectedDriver = detectFormat();
-			MongoStatus partialResult = detectedDriver.readStatus();
+		try (
+			var __1 = bosk.readContext();
+			var __2 = collection.newReadOnlySession()
+		) {
+			MongoStatus partialResult = detectFormat().readStatus();
 			Manifest manifest = loadManifest(); // TODO: Avoid loading the manifest again
-
-			return new MongoStatus(
-				partialResult.error(),
-				manifest,
-				partialResult.stateBytes()
-			);
+			return partialResult.with(driverSettings.preferredDatabaseFormat(), manifest);
 		}
 	}
 

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Manifest.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Manifest.java
@@ -2,7 +2,6 @@ package io.vena.bosk.drivers.mongo;
 
 import io.vena.bosk.StateTreeNode;
 import java.util.Optional;
-import lombok.Value;
 
 public record Manifest(
 	Integer version,

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Manifest.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Manifest.java
@@ -1,6 +1,7 @@
 package io.vena.bosk.drivers.mongo;
 
 import io.vena.bosk.StateTreeNode;
+import io.vena.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
 import java.util.Optional;
 
 public record Manifest(
@@ -16,5 +17,14 @@ public record Manifest(
 
 	public static Manifest forPando(PandoFormat settings) {
 		return new Manifest(1, Optional.empty(), Optional.of(settings));
+	}
+
+	public static Manifest forFormat(DatabaseFormat format) {
+		// TODO: Use a type switch in newer Java versions
+		if (format instanceof PandoFormat p) {
+			return forPando(p);
+		} else {
+			return forSequoia();
+		}
 	}
 }

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriver.java
@@ -5,6 +5,7 @@ import io.vena.bosk.Bosk;
 import io.vena.bosk.BoskDriver;
 import io.vena.bosk.DriverFactory;
 import io.vena.bosk.StateTreeNode;
+import io.vena.bosk.drivers.mongo.status.MongoStatus;
 import java.io.IOException;
 
 public interface MongoDriver<R extends StateTreeNode> extends BoskDriver<R> {
@@ -33,6 +34,8 @@ public interface MongoDriver<R extends StateTreeNode> extends BoskDriver<R> {
 	 * but for unsupported formats or other corruption, YMMV.
 	 */
 	void refurbish() throws IOException;
+
+	MongoStatus readStatus() throws Exception;
 
 	/**
 	 * Frees up resources used by this driver and leaves it unusable.

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/BsonComparator.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/BsonComparator.java
@@ -1,0 +1,72 @@
+package io.vena.bosk.drivers.mongo.status;
+
+import java.util.ArrayList;
+import java.util.Map;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+public class BsonComparator {
+
+	public Difference difference(BsonValue expected, BsonValue actual) {
+		if (expected.getBsonType() != actual.getBsonType()) {
+			return new PrimitiveDifference("");
+		}
+
+		// Now we know they have the same bson type
+
+		if (expected instanceof BsonDocument expectedDoc && actual instanceof BsonDocument actualDoc) {
+			var differences = new ArrayList<Difference>();
+			for (String expectedKey: expectedDoc.keySet()) {
+				var expectedValue = expectedDoc.get(expectedKey);
+				var actualValue = actualDoc.get(expectedKey);
+				if (actualValue == null) {
+					differences.add(new NodeMissing(expectedKey));
+				} else {
+					Difference fieldDifference = difference(expectedValue, actualValue);
+					if (!(fieldDifference instanceof NoDifference)) {
+						differences.add(fieldDifference.withPrefix(expectedKey));
+					}
+				}
+				if (differences.size() >= MAX_DIFFERENCES) {
+					break;
+				}
+			};
+			for (Map.Entry<String, BsonValue> entry : actualDoc.entrySet()) {
+				var expectedValue = expectedDoc.get(entry.getKey());
+				if (expectedValue == null) {
+					differences.add(new UnexpectedNode(entry.getKey()));
+				}
+				if (differences.size() >= MAX_DIFFERENCES) {
+					break;
+				}
+			}
+			return switch (differences.size()) {
+				case 0 -> new NoDifference();
+				case 1 -> differences.get(0);
+				default -> {
+					// To prevent exponential fan-out, permit only max one compound inside another compound
+					int numCompounds = 0;
+					var iter = differences.iterator();
+					while (iter.hasNext()) {
+						var difference = iter.next();
+						if (difference instanceof MultipleDifferences) {
+							if (numCompounds == 0) {
+								numCompounds++;
+							} else {
+								iter.remove();
+							}
+						}
+					}
+					yield new MultipleDifferences("", differences);
+				}
+			};
+		} else if (expected.equals(actual)) {
+			return new NoDifference();
+		} else {
+			return new PrimitiveDifference("");
+		}
+	}
+
+	public static final int MAX_DIFFERENCES = 4;
+
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/Difference.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/Difference.java
@@ -1,0 +1,24 @@
+package io.vena.bosk.drivers.mongo.status;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.As.WRAPPER_OBJECT;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.MINIMAL_CLASS;
+
+// We'd rather use SIMPLE_CLASS but that is a pretty new feature
+// and some users might not have that available in older Jackson versions
+@JsonTypeInfo(use = MINIMAL_CLASS, include = WRAPPER_OBJECT)
+sealed public interface Difference permits
+	NoDifference,
+	SomeDifference
+{
+	Difference withPrefix(String prefix);
+
+	static String prefixed(String prefix, String suffix) {
+		if (suffix.isEmpty()) {
+			return prefix;
+		} else {
+			return prefix + "." + suffix;
+		}
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/ManifestStatus.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/ManifestStatus.java
@@ -1,0 +1,12 @@
+package io.vena.bosk.drivers.mongo.status;
+
+import io.vena.bosk.drivers.mongo.Manifest;
+
+public record ManifestStatus(
+	Manifest expected,
+	Manifest actual
+) {
+	public boolean isIdentical() {
+		return expected.equals(actual);
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/MongoStatus.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/MongoStatus.java
@@ -1,12 +1,15 @@
 package io.vena.bosk.drivers.mongo.status;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.vena.bosk.drivers.mongo.Manifest;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 /**
  * Info about the state of the database, highlighting how it differs from the desired state.
  */
 public record MongoStatus(
-	String error,
+	@JsonInclude(NON_NULL) String error,
 	Manifest manifest,
 	Long stateBytes
 ) { }

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/MongoStatus.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/MongoStatus.java
@@ -2,6 +2,7 @@ package io.vena.bosk.drivers.mongo.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.vena.bosk.drivers.mongo.Manifest;
+import io.vena.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
@@ -10,6 +11,22 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
  */
 public record MongoStatus(
 	@JsonInclude(NON_NULL) String error,
-	Manifest manifest,
-	Long stateBytes
-) { }
+	ManifestStatus manifest,
+	StateStatus state
+) {
+	public MongoStatus with(DatabaseFormat preferredFormat, Manifest actualManifest) {
+		return new MongoStatus(
+			this.error,
+			new ManifestStatus(
+				Manifest.forFormat(preferredFormat),
+				actualManifest
+			),
+			this.state
+		);
+	}
+
+	public boolean isAllClear() {
+		return manifest.isIdentical()
+			&& state.difference() instanceof NoDifference;
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/MongoStatus.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/MongoStatus.java
@@ -1,0 +1,12 @@
+package io.vena.bosk.drivers.mongo.status;
+
+import io.vena.bosk.drivers.mongo.Manifest;
+
+/**
+ * Info about the state of the database, highlighting how it differs from the desired state.
+ */
+public record MongoStatus(
+	String error,
+	Manifest manifest,
+	Long stateBytes
+) { }

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/MultipleDifferences.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/MultipleDifferences.java
@@ -1,0 +1,15 @@
+package io.vena.bosk.drivers.mongo.status;
+
+import java.util.List;
+
+import static io.vena.bosk.drivers.mongo.status.Difference.prefixed;
+
+public record MultipleDifferences(
+	String bsonPath,
+	List<Difference> examples
+) implements SomeDifference {
+	@Override
+	public MultipleDifferences withPrefix(String prefix) {
+		return new MultipleDifferences(prefixed(prefix, bsonPath), this.examples);
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/NoDifference.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/NoDifference.java
@@ -1,0 +1,8 @@
+package io.vena.bosk.drivers.mongo.status;
+
+public record NoDifference() implements Difference {
+	@Override
+	public NoDifference withPrefix(String prefix) {
+		return this;
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/NodeMissing.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/NodeMissing.java
@@ -1,0 +1,12 @@
+package io.vena.bosk.drivers.mongo.status;
+
+import static io.vena.bosk.drivers.mongo.status.Difference.prefixed;
+
+public record NodeMissing(
+	String bsonPath
+) implements SomeDifference {
+	@Override
+	public NodeMissing withPrefix(String prefix) {
+		return new NodeMissing(prefixed(prefix, bsonPath));
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/PrimitiveDifference.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/PrimitiveDifference.java
@@ -1,0 +1,12 @@
+package io.vena.bosk.drivers.mongo.status;
+
+import static io.vena.bosk.drivers.mongo.status.Difference.prefixed;
+
+public record PrimitiveDifference(
+	String bsonPath
+) implements SomeDifference {
+	@Override
+	public PrimitiveDifference withPrefix(String prefix) {
+		return new PrimitiveDifference(prefixed(prefix, bsonPath));
+	}
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/SomeDifference.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/SomeDifference.java
@@ -1,0 +1,10 @@
+package io.vena.bosk.drivers.mongo.status;
+
+sealed public interface SomeDifference extends Difference permits
+	MultipleDifferences,
+	UnexpectedNode,
+	NodeMissing,
+	PrimitiveDifference
+{
+	String bsonPath();
+}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/StateStatus.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/StateStatus.java
@@ -1,0 +1,7 @@
+package io.vena.bosk.drivers.mongo.status;
+
+public record StateStatus(
+	Long revision,
+	Long sizeInBytes,
+	Difference difference
+) { }

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/UnexpectedNode.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/status/UnexpectedNode.java
@@ -1,0 +1,12 @@
+package io.vena.bosk.drivers.mongo.status;
+
+import static io.vena.bosk.drivers.mongo.status.Difference.prefixed;
+
+public record UnexpectedNode(
+	String bsonPath
+) implements SomeDifference {
+	@Override
+	public UnexpectedNode withPrefix(String prefix) {
+		return new UnexpectedNode(prefixed(prefix, bsonPath));
+	}
+}

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/SchemaEvolutionTest.java
@@ -141,6 +141,8 @@ public class SchemaEvolutionTest {
 		try (var __ = toBosk.readContext()) {
 			assertEquals("Distinctive String", toRefs.string().value());
 		}
+
+//		System.out.println("Status: " + ((MongoDriver<?>)toBosk.driver()).readStatus());
 	}
 
 	/**

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/status/BsonComparatorTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/status/BsonComparatorTest.java
@@ -1,0 +1,98 @@
+package io.vena.bosk.drivers.mongo.status;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.vena.bosk.drivers.mongo.status.BsonComparator.MAX_DIFFERENCES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BsonComparatorTest {
+	BsonComparator bsonComparator;
+
+	@BeforeEach
+	void initialize() {
+		bsonComparator = new BsonComparator();
+	}
+
+	@Test
+	void primitiveCombos_work() {
+		checkPrimitiveCombos(
+			new BsonString("hello"),
+			new BsonBoolean(false),
+			new BsonInt32(123),
+			new BsonInt64(123456)
+		);
+	}
+
+	private void checkPrimitiveCombos(BsonValue... values) {
+		for (var left: values) {
+			for (var right: values) {
+				Difference expected;
+				if (left.equals(right)) {
+					expected = new NoDifference();
+				} else {
+					expected = new PrimitiveDifference("");
+				}
+				assertEquals(expected, bsonComparator.difference(left, right));
+			}
+		}
+	}
+
+	@Test
+	void oneDifferentField_works() {
+		var common = new BsonDocument("same1", new BsonInt32(1));
+		var left = common.clone().append("different1", new BsonInt32(2));
+		var right = common.clone().append("different1", new BsonInt32(3));
+		assertEquals(new PrimitiveDifference("different1"),
+			bsonComparator.difference(left, right));
+	}
+
+	@Test
+	void twoDifferentFields_compound() {
+		var left = new BsonDocument("field1", new BsonInt32(1))
+			.append("field2", new BsonInt32(2));
+		var right = new BsonDocument("field1", new BsonInt32(3))
+			.append("field2", new BsonInt32(4));
+		assertEquals(new MultipleDifferences("", List.of(
+			new PrimitiveDifference("field1"),
+			new PrimitiveDifference("field2")
+		)), bsonComparator.difference(left, right));
+	}
+
+	@Test
+	void manyDifferentFields_truncated() {
+		var left = new BsonDocument();
+		var right = new BsonDocument();
+		var differences = new ArrayList<Difference>();
+		for (int i = 1; i <= 1 + MAX_DIFFERENCES; i++) {
+			left.append("field" + i, new BsonInt32(i));
+			right.append("field" + i, new BsonInt32(-i));
+			differences.add(new PrimitiveDifference("field" + i));
+		}
+		var expectedDifference = new MultipleDifferences("", differences.subList(0, MAX_DIFFERENCES));
+
+		assertEquals(expectedDifference, bsonComparator.difference(left, right));
+	}
+
+	@Test
+	void nestedDifferentField_correctlyPrefixed() {
+		var left = new BsonDocument("field1",
+			new BsonDocument("field2",
+			new BsonDocument("field3",
+			new BsonInt32(1))));
+		var right = new BsonDocument("field1",
+			new BsonDocument("field2",
+			new BsonDocument("field3",
+			new BsonInt32(2))));
+		assertEquals(new PrimitiveDifference("field1.field2.field3"),
+			bsonComparator.difference(left, right));
+	}
+}

--- a/example-hello/src/main/java/io/vena/hello/HelloBosk.java
+++ b/example-hello/src/main/java/io/vena/hello/HelloBosk.java
@@ -4,12 +4,10 @@ import io.vena.bosk.Bosk;
 import io.vena.bosk.Catalog;
 import io.vena.bosk.CatalogReference;
 import io.vena.bosk.Identifier;
-import io.vena.bosk.Reference;
 import io.vena.bosk.annotations.ReferencePath;
 import io.vena.bosk.exceptions.InvalidTypeException;
 import io.vena.hello.state.BoskState;
 import io.vena.hello.state.Target;
-import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 @Component


### PR DESCRIPTION
Examines the contents of the MongoDB database and produces a report object. The objects include Jackson annotations to make it painless to return the report object from an HTTP API.

Intended to give human operators some confidence in the state of the database, which is otherwise invisible, particularly because of bosk's high degree of fault tolerance.