### PR TITLE
Add BoskInfo interface

### DIFF
--- a/bosk-core/src/main/java/io/vena/bosk/Bosk.java
+++ b/bosk-core/src/main/java/io/vena/bosk/Bosk.java
@@ -73,7 +73,7 @@ import static lombok.AccessLevel.NONE;
  *
  * @param <R> The type of the state tree's root node
  */
-public class Bosk<R extends StateTreeNode> {
+public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	@Getter private final String name;
 	@Getter private final Identifier instanceID = Identifier.from(randomUUID().toString());
 	@Getter private final BoskDriver<R> driver;
@@ -137,7 +137,7 @@ public class Bosk<R extends StateTreeNode> {
 	 * You can use <code>Bosk::simpleDriver</code> as the
 	 * <code>driverFactory</code> if you don't want any additional driver functionality.
 	 */
-	public static <RR extends StateTreeNode> BoskDriver<RR> simpleDriver(@SuppressWarnings("unused") Bosk<RR> bosk, BoskDriver<RR> downstream) {
+	public static <RR extends StateTreeNode> BoskDriver<RR> simpleDriver(@SuppressWarnings("unused") BoskInfo<RR> boskInfo, BoskDriver<RR> downstream) {
 		return downstream;
 	}
 

--- a/bosk-core/src/main/java/io/vena/bosk/Bosk.java
+++ b/bosk-core/src/main/java/io/vena/bosk/Bosk.java
@@ -525,6 +525,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		localDriver.triggerEverywhere(reg);
 	}
 
+	@Override
 	public void registerHooks(Object receiver) throws InvalidTypeException {
 		HookRegistrar.registerHooks(receiver, this);
 	}
@@ -1026,7 +1027,7 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 	 * correspond to an {@link Identifier} that can be looked up in an
 	 * object that implements {@link EnumerableByIdentifier}. (We are
 	 * not offering to use reflection to look up object fields by name here.)
-	 *
+	 * <p>
 	 * TODO: This is not currently checked or enforced; it will just cause confusing crashes.
 	 * It should throw {@link InvalidTypeException} at the time the Reference is created.
 	 */

--- a/bosk-core/src/main/java/io/vena/bosk/BoskInfo.java
+++ b/bosk-core/src/main/java/io/vena/bosk/BoskInfo.java
@@ -1,0 +1,14 @@
+package io.vena.bosk;
+
+import io.vena.bosk.exceptions.InvalidTypeException;
+
+/**
+ * Provides access to a subset of bosk functionality that is available at the time
+ * the {@link BoskDriver} is built, before the {@link Bosk} itself is fully initialized.
+ */
+public interface BoskInfo<R extends StateTreeNode> {
+	String name();
+	Identifier instanceID();
+	RootReference<R> rootReference();
+	void registerHooks(Object receiver) throws InvalidTypeException;
+}

--- a/bosk-core/src/main/java/io/vena/bosk/DriverFactory.java
+++ b/bosk-core/src/main/java/io/vena/bosk/DriverFactory.java
@@ -1,5 +1,5 @@
 package io.vena.bosk;
 
 public interface DriverFactory<R extends StateTreeNode> {
-	BoskDriver<R> build(Bosk<R> bosk, BoskDriver<R> downstream);
+	BoskDriver<R> build(BoskInfo<R> boskInfo, BoskDriver<R> downstream);
 }

--- a/bosk-core/src/main/java/io/vena/bosk/DriverStack.java
+++ b/bosk-core/src/main/java/io/vena/bosk/DriverStack.java
@@ -23,10 +23,10 @@ public interface DriverStack<R extends StateTreeNode> extends DriverFactory<R> {
 	static <RR extends StateTreeNode> DriverStack<RR> of(DriverFactory<RR>...factories) {
 		return new DriverStack<RR>() {
 			@Override
-			public BoskDriver<RR> build(Bosk<RR> bosk, BoskDriver<RR> downstream) {
+			public BoskDriver<RR> build(BoskInfo<RR> boskInfo, BoskDriver<RR> downstream) {
 				BoskDriver<RR> result = downstream;
 				for (int i = factories.length - 1; i >= 0; i--) {
-					result = factories[i].build(bosk, result);
+					result = factories[i].build(boskInfo, result);
 				}
 				return result;
 			}

--- a/bosk-core/src/main/java/io/vena/bosk/drivers/DiagnosticScopeDriver.java
+++ b/bosk-core/src/main/java/io/vena/bosk/drivers/DiagnosticScopeDriver.java
@@ -26,7 +26,7 @@ public class DiagnosticScopeDriver<R extends StateTreeNode> implements BoskDrive
 	final Function<BoskDiagnosticContext, DiagnosticScope> scopeSupplier;
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Function<BoskDiagnosticContext, DiagnosticScope> scopeSupplier) {
-		return (b,d) -> new DiagnosticScopeDriver<>(d, b.diagnosticContext(), scopeSupplier);
+		return (b,d) -> new DiagnosticScopeDriver<>(d, b.rootReference().diagnosticContext(), scopeSupplier);
 	}
 
 	@Override

--- a/bosk-core/src/main/java/io/vena/bosk/drivers/MirroringDriver.java
+++ b/bosk-core/src/main/java/io/vena/bosk/drivers/MirroringDriver.java
@@ -25,7 +25,7 @@ public class MirroringDriver<R extends StateTreeNode> implements BoskDriver<R> {
 	 * Causes updates to be applied both to <code>mirror</code> and to the downstream driver.
 	 */
 	public static <RR extends StateTreeNode> DriverFactory<RR> targeting(Bosk<RR> mirror) {
-		return (bosk, downstream) -> new ForwardingDriver<>(asList(
+		return (boskInfo, downstream) -> new ForwardingDriver<>(asList(
 			new MirroringDriver<>(mirror),
 			downstream
 		));

--- a/bosk-core/src/test/java/io/vena/bosk/BoskConstructorTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/BoskConstructorTest.java
@@ -128,16 +128,6 @@ public class BoskConstructorTest {
 		}
 	}
 
-	@Test
-	void readContextDuringDriverFactory_throws() {
-		assertThrows(IllegalStateException.class, ()->{
-			new Bosk<>("readContext", SimpleTypes.class, newEntity(), (b,d) -> {
-				try (val __ = b.readContext()) {}
-				return d;
-			});
-		});
-	}
-
 	////////////////
 	//
 	//  Helpers

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Formatter.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Formatter.java
@@ -2,7 +2,7 @@ package io.vena.bosk.drivers.mongo;
 
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.UpdateDescription;
-import io.vena.bosk.Bosk;
+import io.vena.bosk.BoskInfo;
 import io.vena.bosk.Listing;
 import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
@@ -68,12 +68,12 @@ final class Formatter {
 	 */
 	private volatile MapValue<String> lastEventDiagnosticAttributes = MapValue.empty();
 
-	Formatter(Bosk<?> bosk, BsonPlugin bsonPlugin) {
+	Formatter(BoskInfo<?> boskInfo, BsonPlugin bsonPlugin) {
 		this.simpleCodecs = CodecRegistries.fromProviders(
-			bsonPlugin.codecProviderFor(bosk),
+			bsonPlugin.codecProviderFor(boskInfo),
 			new ValueCodecProvider(),
 			new DocumentCodecProvider());
-		this.preferredBoskCodecs = type -> bsonPlugin.getCodec(type, rawClass(type), simpleCodecs, bosk);
+		this.preferredBoskCodecs = type -> bsonPlugin.getCodec(type, rawClass(type), simpleCodecs, boskInfo);
 		this.deserializationScopeFunction = bsonPlugin::newDeserializationScope;
 	}
 

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/MongoDriver.java
@@ -3,6 +3,7 @@ package io.vena.bosk.drivers.mongo;
 import com.mongodb.MongoClientSettings;
 import io.vena.bosk.Bosk;
 import io.vena.bosk.BoskDriver;
+import io.vena.bosk.BoskInfo;
 import io.vena.bosk.DriverFactory;
 import io.vena.bosk.StateTreeNode;
 import io.vena.bosk.drivers.mongo.status.MongoStatus;
@@ -49,6 +50,9 @@ public sealed interface MongoDriver<R extends StateTreeNode>
 	 */
 	void refurbish() throws IOException;
 
+	/**
+	 * Requires a {@link Bosk.ReadContext}.
+	 */
 	MongoStatus readStatus() throws Exception;
 
 	/**
@@ -70,6 +74,6 @@ public sealed interface MongoDriver<R extends StateTreeNode>
 	}
 
 	interface MongoDriverFactory<RR extends StateTreeNode> extends DriverFactory<RR> {
-		@Override MongoDriver<RR> build(Bosk<RR> bosk, BoskDriver<RR> downstream);
+		@Override MongoDriver<RR> build(BoskInfo<RR> boskInfo, BoskDriver<RR> downstream);
 	}
 }

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/PandoFormatDriver.java
@@ -11,8 +11,8 @@ import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.client.result.UpdateResult;
 import com.mongodb.lang.Nullable;
-import io.vena.bosk.Bosk;
 import io.vena.bosk.BoskDriver;
+import io.vena.bosk.BoskInfo;
 import io.vena.bosk.Entity;
 import io.vena.bosk.EnumerableByIdentifier;
 import io.vena.bosk.Identifier;
@@ -86,14 +86,14 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	static final BsonString ROOT_DOCUMENT_ID = new BsonString("|");
 
 	PandoFormatDriver(
-		Bosk<R> bosk,
+		BoskInfo<R> boskInfo,
 		TransactionalCollection<BsonDocument> collection,
 		MongoDriverSettings driverSettings,
 		PandoFormat format, BsonPlugin bsonPlugin,
 		FlushLock flushLock,
 		BoskDriver<R> downstream
 	) {
-		super(bosk.rootReference(), new Formatter(bosk, bsonPlugin));
+		super(boskInfo.rootReference(), new Formatter(boskInfo, bsonPlugin));
 		this.description = getClass().getSimpleName() + ": " + driverSettings;
 		this.settings = driverSettings;
 		this.format = format;

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/SequoiaFormatDriver.java
@@ -9,8 +9,8 @@ import com.mongodb.client.model.changestream.OperationType;
 import com.mongodb.client.model.changestream.UpdateDescription;
 import com.mongodb.client.result.UpdateResult;
 import com.mongodb.lang.Nullable;
-import io.vena.bosk.Bosk;
 import io.vena.bosk.BoskDriver;
+import io.vena.bosk.BoskInfo;
 import io.vena.bosk.Identifier;
 import io.vena.bosk.MapValue;
 import io.vena.bosk.Reference;
@@ -62,14 +62,14 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	static final BsonString DOCUMENT_ID = new BsonString("boskDocument");
 
 	SequoiaFormatDriver(
-		Bosk<R> bosk,
+		BoskInfo<R> boskInfo,
 		MongoCollection<BsonDocument> collection,
 		MongoDriverSettings driverSettings,
 		BsonPlugin bsonPlugin,
 		FlushLock flushLock,
 		BoskDriver<R> downstream
 	) {
-		super(bosk.rootReference(), new Formatter(bosk, bsonPlugin));
+		super(boskInfo.rootReference(), new Formatter(boskInfo, bsonPlugin));
 		this.description = getClass().getSimpleName() + ": " + driverSettings;
 		this.settings = driverSettings;
 		this.collection = collection;

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/AbstractMongoDriverTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/AbstractMongoDriverTest.java
@@ -151,7 +151,7 @@ abstract class AbstractMongoDriverTest {
 	}
 
 	protected <E extends Entity> DriverFactory<E> createDriverFactory() {
-		return (bosk, downstream) -> {
+		return (boskInfo, downstream) -> {
 			MongoDriver<E> driver = MongoDriver.<E>factory(
 				MongoClientSettings.builder(mongoService.clientSettings())
 					.applyToClusterSettings(builder -> {
@@ -164,7 +164,7 @@ abstract class AbstractMongoDriverTest {
 					.build(),
 				driverSettings,
 				new BsonPlugin()
-			).build(bosk, downstream);
+			).build(boskInfo, downstream);
 			tearDownActions.addFirst(driver::close);
 			return driver;
 		};

--- a/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverConformanceTest.java
+++ b/bosk-mongo/src/test/java/io/vena/bosk/drivers/mongo/MongoDriverConformanceTest.java
@@ -56,10 +56,10 @@ class MongoDriverConformanceTest extends DriverConformanceTest {
 	}
 
 	private <R extends StateTreeNode> DriverFactory<R> createDriverFactory() {
-		return (bosk, downstream) -> {
+		return (boskInfo, downstream) -> {
 			MongoDriver<R> driver = MongoDriver.<R>factory(
 				mongoService.clientSettings(), driverSettings, new BsonPlugin()
-			).build(bosk, downstream);
+			).build(boskInfo, downstream);
 			tearDownActions.addFirst(()->{
 				driver.close();
 				mongoService.client()

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/AsyncDriver.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/AsyncDriver.java
@@ -1,7 +1,7 @@
 package io.vena.bosk.drivers;
 
-import io.vena.bosk.Bosk;
 import io.vena.bosk.BoskDriver;
+import io.vena.bosk.BoskInfo;
 import io.vena.bosk.DriverFactory;
 import io.vena.bosk.Identifier;
 import io.vena.bosk.Reference;
@@ -20,7 +20,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 @RequiredArgsConstructor(access = PRIVATE)
 public class AsyncDriver<R extends StateTreeNode> implements BoskDriver<R> {
-	private final Bosk<R> bosk;
+	private final BoskInfo<R> bosk;
 	private final BoskDriver<R> downstream;
 	private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
@@ -68,10 +68,10 @@ public class AsyncDriver<R extends StateTreeNode> implements BoskDriver<R> {
 
 	private void submitAsyncTask(String description, Runnable task) {
 		LOGGER.debug("Submit {}", description);
-		var diagnosticAttributes = bosk.diagnosticContext().getAttributes();
+		var diagnosticAttributes = bosk.rootReference().diagnosticContext().getAttributes();
 		executor.submit(()->{
 			LOGGER.debug("Run {}", description);
-			try (var __ = bosk.diagnosticContext().withOnly(diagnosticAttributes)) {
+			try (var __ = bosk.rootReference().diagnosticContext().withOnly(diagnosticAttributes)) {
 				task.run();
 			}
 			LOGGER.trace("Done {}", description);

--- a/bosk-testing/src/main/java/io/vena/bosk/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/io/vena/bosk/drivers/ReportingDriver.java
@@ -33,7 +33,7 @@ public class ReportingDriver<R extends StateTreeNode> implements BoskDriver<R> {
 	final Runnable flushListener;
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Consumer<UpdateOperation> listener, Runnable flushListener) {
-		return (b,d) -> new ReportingDriver<>(d, b.diagnosticContext(), listener, flushListener);
+		return (b,d) -> new ReportingDriver<>(d, b.rootReference().diagnosticContext(), listener, flushListener);
 	}
 
 	@Override

--- a/lib-testing/src/main/java/io/vena/bosk/AbstractRoundTripTest.java
+++ b/lib-testing/src/main/java/io/vena/bosk/AbstractRoundTripTest.java
@@ -58,9 +58,9 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 	}
 
 	public static <R extends Entity> DriverFactory<R> factoryThatMakesAReference() {
-		return (bosk, downstream) -> {
-			bosk.rootReference();
-			return Bosk.simpleDriver(bosk, downstream);
+		return (boskInfo, downstream) -> {
+			boskInfo.rootReference();
+			return Bosk.simpleDriver(boskInfo, downstream);
 		};
 	}
 
@@ -73,9 +73,9 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 		private final JacksonPlugin jp = new JacksonPlugin();
 
 		@Override
-		public BoskDriver<R> build(Bosk<R> bosk, BoskDriver<R> driver) {
-			return new PreprocessingDriver<R>(driver) {
-				final Module module = jp.moduleFor(bosk);
+		public BoskDriver<R> build(BoskInfo<R> boskInfo, BoskDriver<R> driver) {
+			return new PreprocessingDriver<>(driver) {
+				final Module module = jp.moduleFor(boskInfo);
 				final ObjectMapper objectMapper = new ObjectMapper()
 					.registerModule(module)
 					.enable(INDENT_OUTPUT);
@@ -112,10 +112,10 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 	@RequiredArgsConstructor
 	private static class BsonRoundTripDriverFactory<R extends Entity> implements DriverFactory<R> {
 		@Override
-		public BoskDriver<R> build(Bosk<R> bosk, BoskDriver<R> driver) {
+		public BoskDriver<R> build(BoskInfo<R> boskInfo, BoskDriver<R> driver) {
 			final BsonPlugin bp = new BsonPlugin();
 			return new PreprocessingDriver<R>(driver) {
-				final CodecRegistry codecRegistry = CodecRegistries.fromProviders(bp.codecProviderFor(bosk));
+				final CodecRegistry codecRegistry = CodecRegistries.fromProviders(bp.codecProviderFor(boskInfo));
 
 				/**
 				 * The shortcomings of the Bson library's type system make this
@@ -129,7 +129,7 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 				 */
 				@Override
 				<T> T preprocess(Reference<T> reference, T newValue) {
-					Codec<T> codec = bp.getCodec(reference.targetType(), reference.targetClass(), codecRegistry, bosk);
+					Codec<T> codec = bp.getCodec(reference.targetType(), reference.targetClass(), codecRegistry, boskInfo);
 					BsonDocument document = new BsonDocument();
 					try (BsonDocumentWriter writer = new BsonDocumentWriter(document)) {
 						writer.writeStartDocument();


### PR DESCRIPTION
This is a way of providing `DriverFactory` objects info they need about the bosk without passing the `Bosk` object itself.

I'm not 100% decided whether this is the way to do it permanently, but it seems like a step forward.