### PR TITLE
Don't use compact constructor syntax for Manifest

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Gradle Test
         run: |
-          ./gradlew spotlessCheck spotBugsMain bosk-mongo:test --profile --fail-fast --tests "io.vena.bosk.drivers.mongo.MongoDriverHanoiTest"
+          ./gradlew spotlessCheck spotBugsMain test --profile --fail-fast
         env:
           ORG_GRADLE_PROJECT_ossrhUsername: ${{secrets.OSSRH_USERNAME}}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{secrets.OSSRH_TOKEN}}

--- a/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Manifest.java
+++ b/bosk-mongo/src/main/java/io/vena/bosk/drivers/mongo/Manifest.java
@@ -13,10 +13,15 @@ public record Manifest(
 	Optional<EmptyNode> sequoia,
 	Optional<PandoFormat> pando
 ) implements StateTreeNode {
-	public Manifest {
+	public Manifest(Integer version, Optional<EmptyNode> sequoia, Optional<PandoFormat> pando) {
+		// Note: this could be a compact constructor, but then it won't work:
+		// https://github.com/adoptium/adoptium-support/issues/1025
 		if (sequoia.isPresent() == pando.isPresent()) {
 			throw new IllegalArgumentException("Exactly one format (sequoia or pando) must be specified in manifest");
 		}
+		this.version = version;
+		this.sequoia = sequoia;
+		this.pando = pando;
 	}
 
 	public record EmptyNode() implements StateTreeNode { }


### PR DESCRIPTION
JDK bug here: https://github.com/adoptium/adoptium-support/issues/1025

Also revert a commit that stopped most tests from running. 😱 