### PR TITLE
Disallow primitives

### DIFF
--- a/bosk-core/src/main/java/io/vena/bosk/TypeValidation.java
+++ b/bosk-core/src/main/java/io/vena/bosk/TypeValidation.java
@@ -7,6 +7,7 @@ import io.vena.bosk.annotations.Self;
 import io.vena.bosk.exceptions.InvalidFieldTypeException;
 import io.vena.bosk.exceptions.InvalidTypeException;
 import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -50,6 +51,9 @@ public final class TypeValidation {
 			Class<?> theClass = rawClass(theType);
 			if (!isPublic(theClass.getModifiers())) {
 				throw new InvalidTypeException("Class is not public: " + theClass.getName());
+			} else if (theClass.isPrimitive()) {
+				Class<?> wrapped = MethodType.methodType(theClass).wrap().returnType();
+				throw new InvalidTypeException("Primitive types are not allowed in a bosk; use boxed " + wrapped.getSimpleName() + " instead of primitive " + theClass.getSimpleName());
 			} else if (isSimpleClass(theClass)) {
 				// All allowed
 				return;

--- a/bosk-core/src/main/java/io/vena/bosk/TypeValidation.java
+++ b/bosk-core/src/main/java/io/vena/bosk/TypeValidation.java
@@ -126,7 +126,7 @@ public final class TypeValidation {
 	}
 
 	private static boolean isSimpleClass(Class<?> theClass) {
-		if (theClass.isPrimitive() || theClass.isEnum()) {
+		if (theClass.isEnum()) {
 			return true;
 		} else {
 			for (Class<?> simpleClass: SIMPLE_VALUE_CLASSES) {
@@ -262,6 +262,7 @@ public final class TypeValidation {
 
 	private static final List<Class<?>> SIMPLE_VALUE_CLASSES = asList(
 		Number.class, // TODO: This includes classes like AtomicLong which are not immutable!!
+		Character.class,
 		Boolean.class,
 		String.class);
 

--- a/bosk-core/src/test/java/io/vena/bosk/BoskConstructorTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/BoskConstructorTest.java
@@ -2,7 +2,7 @@ package io.vena.bosk;
 
 import io.vena.bosk.Bosk.DefaultRootFunction;
 import io.vena.bosk.TypeValidationTest.MutableField;
-import io.vena.bosk.TypeValidationTest.Primitives;
+import io.vena.bosk.TypeValidationTest.BoxedPrimitives;
 import io.vena.bosk.TypeValidationTest.SimpleTypes;
 import io.vena.bosk.drivers.ForwardingDriver;
 import io.vena.bosk.exceptions.InvalidTypeException;
@@ -90,7 +90,7 @@ public class BoskConstructorTest {
 		assertThrows(ClassCastException.class, ()->
 			new Bosk<Entity> (
 				"Mismatched root",
-				Primitives.class, // Valid but wrong
+				BoxedPrimitives.class, // Valid but wrong
 				bosk -> newEntity(),
 				Bosk::simpleDriver
 			)

--- a/bosk-core/src/test/java/io/vena/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/BoskLocalReferenceTest.java
@@ -92,7 +92,7 @@ class BoskLocalReferenceTest {
 	@Getter @With @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
 	@EqualsAndHashCode(callSuper = false) @ToString @FieldNameConstants
 	public static class Root implements StateTreeNode {
-		int version;
+		Integer version;
 		Catalog<TestEntity> entities;
 	}
 
@@ -100,7 +100,7 @@ class BoskLocalReferenceTest {
 	@EqualsAndHashCode(callSuper = false) @ToString @FieldNameConstants
 	public static class TestEntity implements Entity {
 		Identifier id;
-		int version;
+		Integer version;
 		Reference<TestEntity> refField;
 		Catalog<TestEntity> catalog;
 		Listing<TestEntity> listing;

--- a/bosk-core/src/test/java/io/vena/bosk/TypeValidationTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/TypeValidationTest.java
@@ -30,7 +30,7 @@ class TypeValidationTest {
 
 	@ParameterizedTest
 	@ValueSource(classes = {
-			Primitives.class,
+			BoxedPrimitives.class,
 			SimpleTypes.class,
 			BoskyTypes.class,
 			AllowedFieldNames.class,
@@ -46,7 +46,11 @@ class TypeValidationTest {
 			String.class,
 			//MissingConstructorArgument.class, // TODO: Currently doesn't work because Bosk is constructor-driven. Figure out what's the system of record here
 			ArrayField.class,
+			BooleanPrimitive.class,
+			BytePrimitive.class,
 			CatalogOfInvalidType.class,
+			CharPrimitive.class,
+			DoublePrimitive.class,
 			DerivedRecordField.class,
 			DerivedRecordType.class,
 			EnclosingNonReference.class,
@@ -56,11 +60,13 @@ class TypeValidationTest {
 			ExtraConstructor.class,
 			ExtraConstructorArgument.class,
 			FieldNameWithDollarSign.class,
+			FloatPrimitive.class,
 			GetterHasParameter.class,
 			GetterReturnsSubtype.class,
 			GetterReturnsSupertype.class,
 			GetterReturnsWrongType.class,
 			HasDeserializationPath.class,
+			IntegerPrimitive.class,
 			ListingOfInvalidType.class,
 			ListValueInvalidSubclass.class,
 			ListValueMutableSubclass.class,
@@ -72,10 +78,12 @@ class TypeValidationTest {
 			ListValueSubclassWithMutableField.class,
 			ListValueSubclassWithTwoConstructors.class,
 			ListValueSubclassWithWrongConstructor.class,
+			LongPrimitive.class,
 			ReferenceToReference.class,
 			SelfNonReference.class,
 			SelfWrongType.class,
 			SelfSubtype.class,
+			ShortPrimitive.class,
 			SideTableWithInvalidKey.class,
 			SideTableWithInvalidValue.class,
 			MutableField.class,
@@ -115,23 +123,25 @@ class TypeValidationTest {
 	// OK, here come the classes...
 	//
 
-	public record Primitives(
-		Identifier id,
-		boolean booleanPrimitive,
-		byte bytePrimitive,
-		short shortPrimitive,
-		int intPrimitive,
-		long longPrimitive,
-		float floatPrimitive,
-		double doublePrimitive,
+	public record BoxedPrimitives(
 		Boolean booleanObject,
 		Byte byteObject,
+		Character charObject,
 		Short shortObject,
 		Integer intObject,
 		Long longObject,
 		Float floatObject,
 		Double doubleObject
-	) implements Entity { }
+	) implements StateTreeNode { }
+
+	public record BooleanPrimitive(boolean field) implements StateTreeNode {}
+	public record BytePrimitive(byte field) implements StateTreeNode {}
+	public record CharPrimitive(char field) implements StateTreeNode {}
+	public record ShortPrimitive(short field) implements StateTreeNode {}
+	public record IntegerPrimitive(int field) implements StateTreeNode {}
+	public record LongPrimitive(long field) implements StateTreeNode {}
+	public record FloatPrimitive(float field) implements StateTreeNode {}
+	public record DoublePrimitive(double field) implements StateTreeNode {}
 
 	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
 	public static final class SimpleTypes implements Entity {
@@ -175,9 +185,9 @@ class TypeValidationTest {
 
 	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
 	public static final class AllowedFieldNames implements StateTreeNode {
-		int justLetters;
-		int someNumbers4U2C;
-		int hereComesAnUnderscore_toldYouSo;
+		Integer justLetters;
+		Integer someNumbers4U2C;
+		Integer hereComesAnUnderscore_toldYouSo;
 	}
 
 	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)

--- a/bosk-core/src/test/java/io/vena/bosk/TypeValidationTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/TypeValidationTest.java
@@ -134,14 +134,53 @@ class TypeValidationTest {
 		Double doubleObject
 	) implements StateTreeNode { }
 
-	public record BooleanPrimitive(boolean field) implements StateTreeNode {}
-	public record BytePrimitive(byte field) implements StateTreeNode {}
-	public record CharPrimitive(char field) implements StateTreeNode {}
-	public record ShortPrimitive(short field) implements StateTreeNode {}
-	public record IntegerPrimitive(int field) implements StateTreeNode {}
-	public record LongPrimitive(long field) implements StateTreeNode {}
-	public record FloatPrimitive(float field) implements StateTreeNode {}
-	public record DoublePrimitive(double field) implements StateTreeNode {}
+	public record BooleanPrimitive(boolean field) implements StateTreeNode {
+		static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsStringIgnoringCase("primitive"));
+		}
+	}
+
+	public record BytePrimitive(byte field) implements StateTreeNode {
+		static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsStringIgnoringCase("primitive"));
+		}
+	}
+
+	public record CharPrimitive(char field) implements StateTreeNode {
+		static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsStringIgnoringCase("primitive"));
+		}
+	}
+
+	public record ShortPrimitive(short field) implements StateTreeNode {
+		static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsStringIgnoringCase("primitive"));
+		}
+	}
+
+	public record IntegerPrimitive(int field) implements StateTreeNode {
+		static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsStringIgnoringCase("primitive"));
+		}
+	}
+
+	public record LongPrimitive(long field) implements StateTreeNode {
+		static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsStringIgnoringCase("primitive"));
+		}
+	}
+
+	public record FloatPrimitive(float field) implements StateTreeNode {
+		static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsStringIgnoringCase("primitive"));
+		}
+	}
+
+	public record DoublePrimitive(double field) implements StateTreeNode {
+		static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsStringIgnoringCase("primitive"));
+		}
+	}
 
 	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
 	public static final class SimpleTypes implements Entity {

--- a/bosk-core/src/test/java/io/vena/bosk/TypeValidationTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/TypeValidationTest.java
@@ -115,24 +115,23 @@ class TypeValidationTest {
 	// OK, here come the classes...
 	//
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class Primitives implements Entity {
-		Identifier id;
-		boolean booleanPrimitive;
-		byte bytePrimitive;
-		short shortPrimitive;
-		int intPrimitive;
-		long longPrimitive;
-		float floatPrimitive;
-		double doublePrimitive;
-		Boolean booleanObject;
-		Byte byteObject;
-		Short shortObject;
-		Integer intObject;
-		Long longObject;
-		Float floatObject;
-		Double doubleObject;
-	}
+	public record Primitives(
+		Identifier id,
+		boolean booleanPrimitive,
+		byte bytePrimitive,
+		short shortPrimitive,
+		int intPrimitive,
+		long longPrimitive,
+		float floatPrimitive,
+		double doublePrimitive,
+		Boolean booleanObject,
+		Byte byteObject,
+		Short shortObject,
+		Integer intObject,
+		Long longObject,
+		Float floatObject,
+		Double doubleObject
+	) implements Entity { }
 
 	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
 	public static final class SimpleTypes implements Entity {


### PR DESCRIPTION
Primitives in state tree nodes already don't work. Until we get them working, type validation ought to disallow them.