### PR TITLE
Superseding readcontext

### DIFF
--- a/bosk-core/src/main/java/io/vena/bosk/Bosk.java
+++ b/bosk-core/src/main/java/io/vena/bosk/Bosk.java
@@ -670,7 +670,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 */
 	public final class ReadContext implements AutoCloseable {
 		final R originalRoot;
-		final R snapshot;
+		final R snapshot; // Mostly for adopt()
 
 		/**
 		 * Creates a {@link ReadContext} for the current thread. If one is already
@@ -693,8 +693,8 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			}
 		}
 
-		private ReadContext(ReadContext toInherit) {
-			R snapshotToInherit = requireNonNull(toInherit.snapshot);
+		private ReadContext(ReadContext toAdopt) {
+			R snapshotToInherit = requireNonNull(toAdopt.snapshot);
 			originalRoot = rootSnapshot.get();
 			if (originalRoot == null) {
 				rootSnapshot.set(this.snapshot = snapshotToInherit);

--- a/bosk-core/src/main/java/io/vena/bosk/Bosk.java
+++ b/bosk-core/src/main/java/io/vena/bosk/Bosk.java
@@ -225,7 +225,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			assertCorrectBosk(target);
 			synchronized (this) {
 				boolean preconditionsSatisfied;
-				try (@SuppressWarnings("unused") ReadContext executionContext = new ReadContext(currentRoot)) {
+				try (@SuppressWarnings("unused") ReadContext executionContext = supersedingReadContext()) {
 					preconditionsSatisfied = !target.exists();
 				}
 				if (preconditionsSatisfied) {
@@ -264,7 +264,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			assertCorrectBosk(precondition);
 			synchronized (this) {
 				boolean preconditionsSatisfied;
-				try (@SuppressWarnings("unused") ReadContext executionContext = new ReadContext(currentRoot)) {
+				try (@SuppressWarnings("unused") ReadContext executionContext = supersedingReadContext()) {
 					preconditionsSatisfied = Objects.equals(precondition.valueIfExists(), requiredValue);
 				}
 				if (preconditionsSatisfied) {
@@ -284,7 +284,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			assertCorrectBosk(precondition);
 			synchronized (this) {
 				boolean preconditionsSatisfied;
-				try (@SuppressWarnings("unused") ReadContext executionContext = new ReadContext(currentRoot)) {
+				try (@SuppressWarnings("unused") ReadContext executionContext = supersedingReadContext()) {
 					preconditionsSatisfied = Objects.equals(precondition.value(), requiredValue);
 				}
 				if (preconditionsSatisfied) {
@@ -797,6 +797,35 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 	 */
 	public final ReadContext readContext() {
 		return new ReadContext();
+	}
+
+	/**
+	 * Establishes a new {@link ReadContext} for the calling thread, similar to {@link #readContext()}, except that
+	 * if the calling thread already has a context, it will be ignored,
+	 * and the newly created context will have a fresh snapshot of the bosk's state tree;
+	 * then, when the returned context is {@link ReadContext#close closed},
+	 * the previous context will be restored.
+	 * <p>
+	 * This is intended to support coordination of distributed logic among multiple threads (or servers) using the same bosk.
+	 * Threads can submit an update, call {@link BoskDriver#flush}, and then use this method
+	 * to inspect the bosk state and determine what effect the update had.
+	 * <p>
+	 * Use this method when it's important to observe the bosk state after a {@link BoskDriver#flush flush}
+	 * performed by the same thread.
+	 * When in doubt, you probably want {@link #readContext()} instead of this.
+	 * This method opens the possibility that the same thread can see two different revisions of the bosk state,
+	 * which can lead to confusing bugs in application code.
+	 * In addition, when the returned context is {@link ReadContext#close closed},
+	 * the bosk state can appear to revert to a prior state, which can be confusing.
+	 *
+	 * @see #readContext()
+	 */
+	public final ReadContext supersedingReadContext() {
+		R snapshot = currentRoot;
+		if (snapshot == null) {
+			throw new IllegalStateException("Bosk constructor has not yet finished; cannot create a ReadContext");
+		}
+		return new ReadContext(snapshot);
 	}
 
 	/**

--- a/bosk-core/src/main/java/io/vena/bosk/DriverStack.java
+++ b/bosk-core/src/main/java/io/vena/bosk/DriverStack.java
@@ -1,6 +1,7 @@
 package io.vena.bosk;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Composes multiple {@link DriverFactory} objects into a stack so that they
@@ -21,21 +22,24 @@ public interface DriverStack<R extends StateTreeNode> extends DriverFactory<R> {
 	 */
 	@SafeVarargs
 	static <RR extends StateTreeNode> DriverStack<RR> of(DriverFactory<RR>...factories) {
-		return new DriverStack<RR>() {
+		return DriverStack.of(Arrays.asList(factories));
+	}
+
+	static <RR extends StateTreeNode> DriverStack<RR> of(List<DriverFactory<RR>> factories) {
+		return new DriverStack<>() {
 			@Override
 			public BoskDriver<RR> build(BoskInfo<RR> boskInfo, BoskDriver<RR> downstream) {
 				BoskDriver<RR> result = downstream;
-				for (int i = factories.length - 1; i >= 0; i--) {
-					result = factories[i].build(boskInfo, result);
+				for (int i = factories.size() - 1; i >= 0; i--) {
+					result = factories.get(i).build(boskInfo, result);
 				}
 				return result;
 			}
 
 			@Override
 			public String toString() {
-				return Arrays.toString(factories);
+				return factories.toString();
 			}
 		};
 	}
-
 }

--- a/bosk-core/src/main/java/io/vena/bosk/HookRegistrar.java
+++ b/bosk-core/src/main/java/io/vena/bosk/HookRegistrar.java
@@ -41,7 +41,7 @@ class HookRegistrar {
 				List<Function<Reference<?>, Object>> argumentFunctions = new ArrayList<>(method.getParameterCount());
 				argumentFunctions.add(ref -> receiverObject); // The "this" pointer
 				for (Parameter p : method.getParameters()) {
-					if (p.getType().isAssignableFrom(Reference.class)) {
+					if (Reference.class.isAssignableFrom(p.getType())) {
 						if (ReferenceUtils.parameterType(p.getParameterizedType(), Reference.class, 0).equals(scope.targetType())) {
 							argumentFunctions.add(ref -> ref);
 						} else {

--- a/bosk-core/src/main/java/io/vena/bosk/bytecode/ClassBuilder.java
+++ b/bosk-core/src/main/java/io/vena/bosk/bytecode/ClassBuilder.java
@@ -376,7 +376,7 @@ public final class ClassBuilder<T> {
 
 		int lineNumber = bestFrame.getLineNumber();
 		if (lineNumber == currentLineNumber) {
-			LOGGER.debug("Omitting line number info; line number is already {}", lineNumber);
+			LOGGER.trace("Omitting line number info; line number is already {}", lineNumber);
 		} else {
 			currentLineNumber = lineNumber;
 			Label label = new Label();

--- a/bosk-core/src/test/java/io/vena/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/BoskLocalReferenceTest.java
@@ -361,8 +361,16 @@ class BoskLocalReferenceTest {
 			assertSame(firstValue, ref.value(), "New ReadContext sees same value as before");
 			bosk.driver().submitReplacement(ref, secondValue);
 			assertSame(firstValue, ref.value(), "Bosk updates not visible during the same ReadContext");
+
+			try (val ___ = bosk.supersedingReadContext()) {
+				assertSame(secondValue, ref.value(), "Superseding context sees the latest state");
+				try (val ____ = bosk.readContext()) {
+					assertSame(secondValue, ref.value(), "Nested context matches outer context");
+				}
+			}
+
 			try (val ___ = bosk.readContext()) {
-				assertSame(firstValue, ref.value(), "Nested context matches outer context");
+				assertSame(firstValue, ref.value(), "Nested context matches original outer context");
 			}
 		}
 

--- a/bosk-core/src/test/java/io/vena/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/io/vena/bosk/BoskLocalReferenceTest.java
@@ -356,44 +356,50 @@ class BoskLocalReferenceTest {
 		assertThrows(IllegalStateException.class, ref::value, "Can't read from Bosk between ReadContexts");
 
 		T secondValue = updater.apply(firstValue);
+		T thirdValue = updater.apply(secondValue);
 		try (val __ = bosk.readContext()) {
 			assertSame(firstValue, ref.value(), "New ReadContext sees same value as before");
 			bosk.driver().submitReplacement(ref, secondValue);
 			assertSame(firstValue, ref.value(), "Bosk updates not visible during the same ReadContext");
+			try (val ___ = bosk.readContext()) {
+				assertSame(firstValue, ref.value(), "Nested context matches outer context");
+			}
 		}
 
-		try (val context = bosk.readContext()) {
+		try (
+			val context = bosk.readContext();
+		) {
 			assertSame(secondValue, ref.value(), "New value is visible in next ReadContext");
-			bosk.driver().submitReplacement(ref, firstValue);
+			bosk.driver().submitReplacement(ref, thirdValue);
 			assertSame(secondValue, ref.value(), "Bosk updates still not visible during the same ReadContext");
 			ExecutorService executor = Executors.newFixedThreadPool(1);
-			Future<?> future = executor.submit(()->{
-				IllegalStateException caught = null;
-				try {
-					ref.value();
-				} catch (IllegalStateException e) {
-					caught = e;
-				} catch (Throwable e) {
-					fail("Unexpected exception: ", e);
-				}
-				assertNotNull(caught, "New thread should not have any scope by default, so an exception should be thrown");
-				try (val unrelatedContext = bosk.readContext()) {
-					assertSame(firstValue, ref.value(), "Separate thread should see the latest state");
-				}
-				try (val inheritedContext = context.adopt()) {
-					assertSame(secondValue, ref.value(), "Inherited scope should see the same state");
-
-					try (val reinheritedContext = inheritedContext.adopt()) {
-						// Harmless to re-assert a scope you're already in
-						assertSame(secondValue, ref.value(), "Inner scope should see the same state");
+			try {
+				Future<?> future = executor.submit(() -> {
+					IllegalStateException caught = null;
+					try {
+						ref.value();
+					} catch (IllegalStateException e) {
+						caught = e;
+					} catch (Throwable e) {
+						fail("Unexpected exception: ", e);
 					}
-				}
-			});
-			future.get();
-		}
+					assertNotNull(caught, "New thread should not have any scope by default, so an exception should be thrown");
+					try (val unrelatedContext = bosk.readContext()) {
+						assertSame(thirdValue, ref.value(), "Separate thread should see the latest state");
+					}
+					try (val inheritedContext = context.adopt()) {
+						assertSame(secondValue, ref.value(), "Inherited scope should see the same state");
 
-		try (val __ = bosk.readContext()) {
-			assertSame(firstValue, ref.value(), "Referenced item is restored to its original state");
+						try (val reinheritedContext = inheritedContext.adopt()) {
+							// Harmless to re-assert a scope you're already in
+							assertSame(secondValue, ref.value(), "Inner scope should see the same state");
+						}
+					}
+				});
+				future.get();
+			} finally {
+				executor.shutdown();
+			}
 		}
 
 		// Reset the bosk for subsequent tests.  This is necessary because we do

--- a/bosk-core/src/test/java/io/vena/bosk/ReferenceUtilsTest_parameterType.java
+++ b/bosk-core/src/test/java/io/vena/bosk/ReferenceUtilsTest_parameterType.java
@@ -89,6 +89,18 @@ class ReferenceUtilsTest_parameterType {
 		checkStringAndIntegerParameters(type, BinaryClass.class);
 	}
 
+	@Test
+	void testParameterWithParameters() throws NoSuchFieldException {
+		abstract class TestClass {
+			public SideTableReference<Entity, String> sideTable;
+		}
+		Type type = TestClass.class.getDeclaredField("sideTable").getGenericType();
+		Type targetType = parameterType(type, Reference.class, 0);
+		Type keyType = parameterType(targetType, SideTable.class, 0);
+		Type valueType = parameterType(targetType, SideTable.class, 1);
+		assertEquals(Entity.class, keyType);
+		assertEquals(String.class, valueType);
+	}
 
 	private void checkStringAndIntegerParameters(Type type, Class<?> expectedClass) {
 		assertEquals(String.class,  parameterType(type, expectedClass, 0));


### PR DESCRIPTION
Allow a `ReadContext` to be created that sees the latest bosk state rather than whatever is in any surrounding `ReadContext`.

This fairly simple change opens the door to using bosk to coordinate load-balanced work rather than just replicated work that happens on every node.