### PR TITLE
Backport ClassBuilder fix

### DIFF
--- a/bosk-core/src/main/java/io/vena/bosk/bytecode/ClassBuilder.java
+++ b/bosk-core/src/main/java/io/vena/bosk/bytecode/ClassBuilder.java
@@ -416,7 +416,9 @@ public final class ClassBuilder<T> {
 
 	public static CallSite retrieveCallSite(MethodHandles.Lookup __, String name, MethodType ___) {
 		LOGGER.debug("retrieveCallSite({})", name);
-		return requireNonNull(CALL_SITES_BY_NAME.remove(name));
+		// We'd like to call remove here, but under some circumstances, bootstrap methods
+		// can be called multiple times, so we need to leave the CalLSite in the map.
+		return requireNonNull(CALL_SITES_BY_NAME.get(name));
 	}
 
 	private static final Method RETRIEVE_CALL_SITE_METHOD;


### PR DESCRIPTION
From https://github.com/boskworks/bosk/commit/3d3b2b69a63b0246d27e81484094926a53ba51e7

### Explanation

Previously, we were calling `Map.remove` in an invokedynamic bootstrap method, because once the bootstrap was complete, the map entry was no longer needed.

The problem is, under certain circumstances, the JVM is allowed to call the bootstrap method multiple times. Since we had removed the map entry, subsequent calls would fail.

It's not clear whether this caused any actual problems, or merely threw spurious exceptions. I didn't observe any test failures caused by this problem, but I thought we're better safe than sorry.

### Risk

This change causes some more memory to be retained in the form of entries in the `CALL_SITES_BY_NAME` map. The way Vena uses bosk, I'd guesstimate this will consume an extra few kilobytes.